### PR TITLE
Fix the link error in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Welcome to the PlatON source code repository! This software is Ethereum-based an
 ## Building the source
 
 For prerequisites and detailed build instructions please read the
-[Installation Instructions](http://192.168.9.66/PlatON/wiki/wikis/home)
+[Installation Instructions](https://github.com/PlatONnetwork/wiki/wiki)
 on the wiki.
 
 Building platon requires both a Go (version 1.7 or later) and a C compiler.
@@ -121,4 +121,4 @@ Check the balance
 
 OK, it seems that the chain is running correctly
 
-For more information, please visit our [wiki](http://192.168.9.66/PlatON/wiki/wikis/home)
+For more information, please visit our [wiki](https://github.com/PlatONnetwork/wiki/wiki)


### PR DESCRIPTION
Change the inner link address to our github's wiki address.