### PR TITLE
megrge ppos 0.6 fix some bug

### DIFF
--- a/consensus/cbft/cbft.go
+++ b/consensus/cbft/cbft.go
@@ -1023,7 +1023,8 @@ func (cbft *Cbft) blockReceiver(tmp *BlockExt) error {
 
 	// TODO
 	//isLegal := cbft.isLegal(rcvTime, producerID)
-	blockNumber := block.Number()
+	// TODO: the code that check if legal is commented temporarily.
+	/*blockNumber := block.Number()
 	parentNumber := new(big.Int).Sub(blockNumber, common.Big1)
 	isLegal := cbft.isLegal(rcvTime, parentNumber, block.ParentHash(), blockNumber, producerID)
 	log.Debug("check if block is legal",
@@ -1035,7 +1036,8 @@ func (cbft *Cbft) blockReceiver(tmp *BlockExt) error {
 		"producerID", producerID)
 	if !isLegal {
 		return errIllegalBlock
-	}
+	}*/
+
 	//to check if there's a existing blockExt for received block
 	//sometime we'll receive the block's sign before the block self.
 	blockExt := cbft.findBlockExt(block.Hash())

--- a/consensus/cbft/ppos.go
+++ b/consensus/cbft/ppos.go
@@ -236,7 +236,7 @@ func (p *ppos) SetCandidateContextOption(blockChain *core.BlockChain, initialNod
 		count := 0
 		blockArr := make([]*types.Block, 0)
 		for {
-			if currBlockNumber == genesis.NumberU64() || count == 2*common.BaseIrrCount {
+			if currBlockNumber == genesis.NumberU64() || count == common.BaseIrrCount {
 				break
 			}
 
@@ -500,7 +500,7 @@ func (p *ppos) UpdateNodeList(blockChain *core.BlockChain, blocknumber *big.Int,
 	count := 0
 	blockArr := make([]*types.Block, 0)
 	for {
-		if curBlockNumber == genesis.NumberU64() || count == 2*common.BaseIrrCount {
+		if curBlockNumber == genesis.NumberU64() || count == common.BaseIrrCount {
 			break
 		}
 		parentNum := curBlockNumber - 1

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -830,7 +830,6 @@ const (
 // Rollback is designed to remove a chain of links from the database that aren't
 // certain enough to be valid.
 func (bc *BlockChain) Rollback(chain []common.Hash) {
-	log.Info("======BlockChain Rollback======")
 	bc.mu.Lock()
 	defer bc.mu.Unlock()
 
@@ -1129,7 +1128,7 @@ func (bc *BlockChain) WriteBlockWithState(block *types.Block, receipts []*types.
 	if err := batch.Write(); err != nil {
 		return NonStatTy, err
 	}
-	log.Debug("Read block signatures", "WriteStatus", status, "hash", block.Hash(), "number", block.NumberU64(), "signs", rawdb.ReadBody(bc.db, block.Hash(), block.NumberU64()).Signatures)
+	log.Trace("Read block signatures", "WriteStatus", status, "hash", block.Hash(), "number", block.NumberU64(), "signs", rawdb.ReadBody(bc.db, block.Hash(), block.NumberU64()).Signatures)
 
 	// Set new head.
 	if status == CanonStatTy {

--- a/core/state/database.go
+++ b/core/state/database.go
@@ -18,13 +18,12 @@ package state
 
 import (
 	"fmt"
-	"github.com/PlatONnetwork/PlatON-Go/log"
 	"sync"
 
 	"github.com/PlatONnetwork/PlatON-Go/common"
 	"github.com/PlatONnetwork/PlatON-Go/ethdb"
 	"github.com/PlatONnetwork/PlatON-Go/trie"
-	lru "github.com/hashicorp/golang-lru"
+	"github.com/hashicorp/golang-lru"
 )
 
 // Trie cache generation limit after which to evict trie nodes from memory.
@@ -100,15 +99,11 @@ func (db *cachingDB) OpenTrie(root common.Hash) (Trie, error) {
 	db.mu.Lock()
 	defer db.mu.Unlock()
 
-	log.Debug("------database OpenTrie------", "GoRoutineID", common.CurrentGoRoutineID(), "root", root)
 	for i := len(db.pastTries) - 1; i >= 0; i-- {
 		if db.pastTries[i].Hash() == root {
-			log.Debug("------database OpenTrie pastTries----", "GoRoutineID", common.CurrentGoRoutineID(), "root", root)
 			return cachedTrie{db.pastTries[i].Copy(), db}, nil
 		}
 	}
-
-	log.Debug("------database OpenTrie new trie------", "GoRoutineID", common.CurrentGoRoutineID(), "root", root)
 
 	tr, err := trie.NewSecure(root, db.db, MaxTrieCacheGen)
 	if err != nil {


### PR DESCRIPTION
Signed-off-by: GavinXu520 <meiyan532484710@163.com>

summary：

1、The number of blocks that read statedb when the node starts  ：
origin：
if currBlockNumber == genesis.NumberU64() || count == 2*common.BaseIrrCount {
change：
if currBlockNumber == genesis.NumberU64() || count == common.BaseIrrCount {

2. cbft.go fix bug

In the function: blockReceiver(tmp *BlockExt)
origin:
blockNumber := block.Number()
	parentNumber := new(big.Int).Sub(blockNumber, common.Big1)
	isLegal := cbft.isLegal(rcvTime, parentNumber, block.ParentHash(), blockNumber, producerID)
	log.Debug("check if block is legal",
		"result", isLegal,
		"hash", block.Hash(),
		"number", block.NumberU64(),
		"parentHash", block.ParentHash(),
		"rcvTime", rcvTime,
		"producerID", producerID)
	if !isLegal {
		return errIllegalBlock
	}
change： Comment it ！！

3. delete some invalid comments