### PR TITLE
Deterministic nonce generation

### DIFF
--- a/crypto/rfc6979/rfc6979.go
+++ b/crypto/rfc6979/rfc6979.go
@@ -1,0 +1,122 @@
+package rfc6979
+
+import (
+	"bytes"
+	"crypto/hmac"
+	"hash"
+	"math/big"
+	"crypto/sha256"
+	"github.com/PlatONnetwork/PlatON-Go/crypto/secp256k1"
+	"crypto/ecdsa"
+)
+
+const (
+	tryLimit = 10000
+)
+// mac returns an HMAC of the given key and message.
+func hmac_k(alg func() hash.Hash, k, m[]byte) []byte {
+	h := hmac.New(alg, k)
+	h.Write(m)
+	return h.Sum(nil)
+}
+
+// https://tools.ietf.org/html/rfc6979#section-2.3.2
+func bits2int(in []byte, qlen int) *big.Int {
+	vlen := len(in) * 8
+	v := new(big.Int).SetBytes(in)
+	if vlen > qlen {
+		v = new(big.Int).Rsh(v, uint(vlen-qlen))
+	}
+	return v
+}
+
+// https://tools.ietf.org/html/rfc6979#section-2.3.3
+func int2octets(v *big.Int, rlen int) []byte {
+	out := v.Bytes()
+
+	// pad with zeros if it's too short
+	if len(out) < rlen {
+		out2 := make([]byte, rlen)
+		copy(out2[rlen-len(out):], out)
+		return out2
+	}
+	// drop most significant bytes if it's too long
+	if len(out) > rlen {
+		out2 := make([]byte, rlen)
+		copy(out2, out[len(out)-rlen:])
+		return out2
+	}
+
+	return out
+}
+
+// https://tools.ietf.org/html/rfc6979#section-2.3.4
+func bits2octets(in []byte, q *big.Int, qlen, rlen int) []byte {
+	z1 := bits2int(in, qlen)
+	z2 := new(big.Int).Sub(z1, q)
+	if z2.Sign() < 0 {
+		return int2octets(z1, rlen)
+	}
+	return int2octets(z2, rlen)
+}
+
+var one = big.NewInt(1)
+
+// https://tools.ietf.org/html/rfc6979#section-3.2
+func generate_k(q, x *big.Int, alg func() hash.Hash, hash []byte, test func(*big.Int) bool) {
+	qlen := q.BitLen()
+	hlen := alg().Size()
+	rlen := (qlen + 7) >> 3
+	bx := append(int2octets(x, rlen), bits2octets(hash, q, qlen, rlen)...)
+	// Step B
+	v := bytes.Repeat([]byte{0x01}, hlen)
+	// Step C
+	k := bytes.Repeat([]byte{0x00}, hlen)
+	// Step D
+	k = hmac_k(alg, k, append(append(v, 0x00), bx...))
+	// Step E
+	v = hmac_k(alg, k, v)
+	// Step F
+	k = hmac_k(alg, k, append(append(v, 0x01), bx...))
+	// Step G
+	v = hmac_k(alg, k, v)
+	// Step H
+	for i := int64(0); i < tryLimit; i++ {
+		// Step H1
+		var t []byte
+		// Step H2
+		for len(t) < qlen/8 {
+			v = hmac_k(alg, k, v)
+			t = append(t, v...)
+		}
+		// Step H3
+		secret := bits2int(t, qlen)
+		if secret.Cmp(one) >= 0 && secret.Cmp(q) < 0 && test(secret) {
+			return
+		}
+		k = hmac_k(alg, k, append(v, 0x00))
+		v = hmac_k(alg, k, v)
+	}
+	panic("generate_k: couldn't generate a new k")
+}
+
+func ECVRF_nonce_generation(sk []byte,m []byte)(*ecdsa.PrivateKey, error){
+	curve := secp256k1.S256()
+
+	hash := sha256.New()
+	hash.Write(m)
+	h := hash.Sum(nil)
+
+	var sec *big.Int
+	generate_k(curve.N,new(big.Int).SetBytes(sk), sha256.New, h, func(k *big.Int) bool {
+		sec = k
+		return true
+	})
+	priv := new(ecdsa.PrivateKey)
+	priv.PublicKey.Curve = curve
+	priv.D = sec
+	priv.PublicKey.X, priv.PublicKey.Y = curve.ScalarBaseMult(sec.Bytes())
+
+	return priv,nil
+}
+

--- a/crypto/rfc6979/rfc6979_test.go
+++ b/crypto/rfc6979/rfc6979_test.go
@@ -1,0 +1,42 @@
+package rfc6979
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"math/big"
+	"testing"
+	"fmt"
+	"crypto/ecdsa"
+	"crypto/rand"
+	"github.com/PlatONnetwork/PlatON-Go/crypto/secp256k1"
+)
+
+// https://tools.ietf.org/html/rfc6979#appendix-A.1
+func TestGenerate_k(t *testing.T) {
+	q, _ := new(big.Int).SetString("4000000000000000000020108A2E0CC0D99F8A5EF", 16)
+	x, _ := new(big.Int).SetString("09A4D6792295A7F730FC3F2B49CBC0F62E862272F", 16)
+	hash, _ := hex.DecodeString("AF2BDBE1AA9B6EC1E2ADE1D694F41FC71A831D0268E9891562113D8A62ADD1BF")
+	expected, _ := new(big.Int).SetString("23AF4074C90A02B3FE61D286D5C87F425E6BDD81B", 16)
+	var actual *big.Int
+	generate_k(q, x, sha256.New, hash, func(k *big.Int) bool {
+		actual = k
+		return true
+	})
+
+	if actual.Cmp(expected) != 0 {
+		t.Errorf("Expected %x, got %x", expected, actual)
+	}
+}
+
+func TestDeterministicNonce(t *testing.T) {
+	curve := secp256k1.S256()
+	sk, err := ecdsa.GenerateKey(curve, rand.Reader)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("sk:%x\n",sk.D.Bytes())
+	msg := "hello"
+	k, err := ECVRF_nonce_generation(sk.D.Bytes(), []byte(msg))
+	fmt.Printf("k:%x\n",k.D.Bytes())
+
+}

--- a/crypto/secp256k1/ext.h
+++ b/crypto/secp256k1/ext.h
@@ -128,3 +128,16 @@ int secp256k1_ext_scalar_mul(const secp256k1_context* ctx, unsigned char *point,
 	secp256k1_scalar_clear(&s);
 	return ret;
 }
+
+int secp256k1_pubkey_is_infinity(const secp256k1_context* ctx, unsigned char *point) {
+	secp256k1_fe feX, feY;
+	secp256k1_ge ge;
+	secp256k1_scalar s;
+	ARG_CHECK(point != NULL);
+	(void)ctx;
+	secp256k1_fe_set_b32(&feX, point);
+	secp256k1_fe_set_b32(&feY, point+32);
+	secp256k1_ge_set_xy(&ge, &feX, &feY);
+	return secp256k1_ge_is_infinity(&ge);
+}
+

--- a/crypto/secp256k1/libsecp256k1/src/modules/recovery/main_impl.h
+++ b/crypto/secp256k1/libsecp256k1/src/modules/recovery/main_impl.h
@@ -190,4 +190,6 @@ int secp256k1_ecdsa_recover(const secp256k1_context* ctx, secp256k1_pubkey *pubk
     }
 }
 
+
+
 #endif

--- a/crypto/secp256k1/secp256.go
+++ b/crypto/secp256k1/secp256.go
@@ -28,6 +28,7 @@ import (
 	"errors"
 	"math/big"
 	"unsafe"
+	"github.com/PlatONnetwork/PlatON-Go/common/math"
 )
 
 var context *C.secp256k1_context
@@ -165,3 +166,13 @@ func checkSignature(sig []byte) error {
 	}
 	return nil
 }
+
+func PubkeyNotInfinity(x, y *big.Int) bool {
+	point := make([]byte, 64)
+	math.ReadBits(x, point[:32])
+	math.ReadBits(y, point[32:])
+	pointPtr := (*C.uchar)(unsafe.Pointer(&point[0]))
+	res := C.secp256k1_pubkey_is_infinity(context, pointPtr)
+	return  res ==0
+}
+

--- a/crypto/secp256k1/secp256_test.go
+++ b/crypto/secp256k1/secp256_test.go
@@ -12,6 +12,7 @@ import (
 	"encoding/hex"
 	"io"
 	"testing"
+	"fmt"
 )
 
 const TestCount = 1000
@@ -214,6 +215,16 @@ func TestRecoverSanity(t *testing.T) {
 	if !bytes.Equal(pubkey1, pubkey2) {
 		t.Errorf("pubkey mismatch: want: %x have: %x", pubkey1, pubkey2)
 	}
+}
+
+func TestSecp256k1_NotInfinity(t *testing.T) {
+	sk,err := ecdsa.GenerateKey(S256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fmt.Printf("sk=%x\n", sk.D.Bytes())
+	res := PubkeyNotInfinity(sk.X,sk.Y)
+	fmt.Println(res)
 }
 
 func BenchmarkSign(b *testing.B) {

--- a/crypto/vrf/vrf_secp256k1.go
+++ b/crypto/vrf/vrf_secp256k1.go
@@ -20,12 +20,12 @@ package vrf
 
 import (
 	"bytes"
-	"crypto/ecdsa"
-	"crypto/rand"
 	"crypto/sha256"
 	"errors"
 	"github.com/PlatONnetwork/PlatON-Go/crypto/secp256k1"
 	"math/big"
+	"crypto/ecdsa"
+	"crypto/rand"
 )
 
 const (
@@ -47,6 +47,7 @@ func eCVRF_prove(pk []byte, sk []byte, m []byte) (pi []byte, err error) {
 	hx, hy := ECVRF_hash_to_curve(m, pk)
 	r := ECP2OS(curve.ScalarMult(hx, hy, sk))
 	k, err := ecdsa.GenerateKey(curve, rand.Reader)
+///	k, err := rfc6979.ECVRF_nonce_generation(sk,m)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
Add ECVRF_nonce_generation() and PubkeyNotInfinity() interface. ECVRF_nonce_generation  is used to generate deterministic random numbers based on private keys and seeds.  PubkeyNotInfinity  is to determine if the public key is infinite.