### PR TITLE
Feature/bump version to 0.7.3

### DIFF
--- a/core/vm/gov_contract.go
+++ b/core/vm/gov_contract.go
@@ -334,6 +334,13 @@ func (gc *GovContract) getAccuVerifiersCount(proposalID, blockHash common.Hash) 
 		"blockHash", blockHash,
 		"proposalID", proposalID)
 
+	proposal, err := gov.GetProposal(proposalID, gc.Evm.StateDB)
+	if err != nil {
+		return gc.callHandler("getAccuVerifiesCount", nil, common.InternalError.Wrap(err.Error()))
+	} else if proposal == nil {
+		return gc.callHandler("getAccuVerifiesCount", nil, gov.ProposalNotFound)
+	}
+
 	list, err := gov.ListAccuVerifier(blockHash, proposalID)
 	if err != nil {
 		return gc.callHandler("getAccuVerifiesCount", nil, common.InternalError.Wrap(err.Error()))
@@ -341,7 +348,7 @@ func (gc *GovContract) getAccuVerifiersCount(proposalID, blockHash common.Hash) 
 
 	yeas, nays, abstentions, err := gov.TallyVoteValue(proposalID, gc.Evm.StateDB)
 	if err != nil {
-		return gc.callHandler("getAccuVerifiesCount", []uint16{uint16(0), uint16(0), uint16(0), uint16(0)}, common.InternalError.Wrap(err.Error()))
+		return gc.callHandler("getAccuVerifiesCount", nil, common.InternalError.Wrap(err.Error()))
 	}
 
 	returnValue := []uint16{uint16(len(list)), yeas, nays, abstentions}

--- a/x/gov/gov_db.go
+++ b/x/gov/gov_db.go
@@ -167,6 +167,13 @@ func SetTallyResult(tallyResult TallyResult, state xcom.StateDB) error {
 }
 
 func GetTallyResult(proposalID common.Hash, state xcom.StateDB) (*TallyResult, error) {
+	proposal, err := GetProposal(proposalID, state)
+	if err != nil {
+		return nil, err
+	} else if proposal == nil {
+		return nil, ProposalNotFound
+	}
+
 	value := state.GetState(vm.GovContractAddr, KeyTallyResult(proposalID))
 
 	if len(value) == 0 {

--- a/x/gov/gov_db_test.go
+++ b/x/gov/gov_db_test.go
@@ -383,6 +383,11 @@ func TestGovDB_TallyResult(t *testing.T) {
 	Init()
 	defer snapdbTest.Clear()
 
+	proposal := getVerProposal(common.Hash{0x03})
+	if e := SetProposal(proposal, statedb); e != nil {
+		t.Errorf("set proposal error,%s", e)
+	}
+
 	proposalID := common.Hash{0x03}
 
 	tallyResult := TallyResult{
@@ -400,6 +405,38 @@ func TestGovDB_TallyResult(t *testing.T) {
 
 	if result, err := GetTallyResult(proposalID, statedb); err != nil {
 		t.Fatalf("get vote result error,%s", err)
+	} else {
+		if result.Status != tallyResult.Status {
+			t.Fatalf("get vote result error")
+		}
+	}
+}
+
+func TestGovDB_GetTallyResult_ProposalNotFound(t *testing.T) {
+	Init()
+	defer snapdbTest.Clear()
+
+	proposalID := common.Hash{0x03}
+
+	tallyResult := TallyResult{
+		ProposalID:    proposalID,
+		Yeas:          15,
+		Nays:          0,
+		Abstentions:   0,
+		AccuVerifiers: 1000,
+		Status:        Pass,
+	}
+
+	if err := SetTallyResult(tallyResult, statedb); err != nil {
+		t.Fatalf("set vote result error")
+	}
+
+	if result, err := GetTallyResult(proposalID, statedb); err != nil {
+		if err == ProposalNotFound {
+			t.Log("get expected error")
+		} else {
+			t.Fatalf("get vote result error,%s", err)
+		}
 	} else {
 		if result.Status != tallyResult.Status {
 			t.Fatalf("get vote result error")


### PR DESCRIPTION
returns ProposalNotFound, not just a nil value if proposalID is wrong in GetTallyResult.
returns ProposalNotFound, not just a nil value if proposalID is wrong in getAccVerifiersCount.
add more unit tests in gov_contract_test.go
add unit test for GetTallyResult in gov_db_test.go
