### PR TITLE
Feature/bump version to 0.7.4

### DIFF
--- a/core/vm/gov_contract.go
+++ b/core/vm/gov_contract.go
@@ -463,7 +463,7 @@ func (gc *GovContract) callHandler(funcName string, resultValue interface{}, err
 	jsonByte, e := json.Marshal(resultValue)
 	if nil != e {
 		log.Error("call GovContract failed", "method", funcName, "blockNumber", gc.Evm.BlockNumber.Uint64(),
-			"txHash", gc.Evm.StateDB.TxHash(), "err", err)
+			"txHash", gc.Evm.StateDB.TxHash(), "err", e)
 		resultBytes := xcom.NewFailedResult(e)
 		return resultBytes, nil
 	} else {

--- a/x/gov/gov.go
+++ b/x/gov/gov.go
@@ -575,7 +575,7 @@ func GetGovernParamValue(module, name string, blockNumber uint64, blockHash comm
 		return "", err
 	}
 	if paramValue == nil {
-		return "", common.InternalError
+		return "", UnsupportedGovernParam
 	} else {
 		if blockNumber >= paramValue.ActiveBlock {
 			return paramValue.Value, nil

--- a/x/gov/gov_err.go
+++ b/x/gov/gov_err.go
@@ -36,4 +36,5 @@ var (
 	UnsupportedGovernParam            = common.NewBizError(302031, "unsupported govern parameter")
 	VotingParamProposalExist          = common.NewBizError(302032, "another param proposal at voting stage")
 	GovernParamValueError             = common.NewBizError(302033, "govern parameter value error")
+	ParamProposalIsSameValue          = common.NewBizError(302033, "the new value of the parameter proposal is the same as the old value")
 )

--- a/x/gov/gov_types.go
+++ b/x/gov/gov_types.go
@@ -45,5 +45,5 @@ type ParamValue struct {
 type GovernParam struct {
 	ParamItem     *ParamItem
 	ParamValue    *ParamValue
-	ParamVerifier ParamVerifier
+	ParamVerifier ParamVerifier `json:"-"`
 }

--- a/x/gov/proposals.go
+++ b/x/gov/proposals.go
@@ -416,6 +416,8 @@ func (pp *ParamProposal) Verify(submitBlock uint64, blockHash common.Hash, state
 		return err
 	} else if param == nil {
 		return UnsupportedGovernParam
+	} else if param.ParamValue.Value == pp.NewValue {
+		return ParamProposalIsSameValue
 	}
 
 	if exist, err := FindVotingProposal(blockHash, state, Param, Version); err != nil {


### PR DESCRIPTION
1. Log the marshaling error of rpc result.
2. Ignore the GovernParam.ParamVerifier when marshaling GovernParam.
3. Add more unit tests for ParamProposal.
4. Return UnsupportedGovernParam but not InternalError if GovernParam is not found.
5.The value of a parameter proposal should be different from the old value.
 