### PR TITLE
Feature/bump version to 0.7.4

### DIFF
--- a/cmd/rlpdump/main.go
+++ b/cmd/rlpdump/main.go
@@ -173,6 +173,7 @@ func main() {
 			gov.UnsupportedGovernParam.Code:            gov.UnsupportedGovernParam.Msg,
 			gov.VotingParamProposalExist.Code:          gov.VotingParamProposalExist.Msg,
 			gov.GovernParamValueError.Code:             gov.GovernParamValueError.Msg,
+			gov.ParamProposalIsSameValue.Code:          gov.ParamProposalIsSameValue.Msg,
 		}
 
 		codeStr := string(args[0])

--- a/core/vm/gov_contract.go
+++ b/core/vm/gov_contract.go
@@ -409,6 +409,8 @@ func (gc *GovContract) getGovernParamValue(module, name string) ([]byte, error) 
 	log.Debug("call getGovernParamValue of GovContract",
 		"from", from.Hex(),
 		"txHash", txHash,
+		"module", module,
+		"name", name,
 		"blockNumber", blockNumber)
 
 	value, err := gov.GetGovernParamValue(module, name, blockNumber, blockHash)
@@ -425,6 +427,7 @@ func (gc *GovContract) listGovernParam(module string) ([]byte, error) {
 	log.Debug("call listGovernParam of GovContract",
 		"from", from.Hex(),
 		"txHash", txHash,
+		"module", module,
 		"blockNumber", blockNumber)
 
 	paramList, err := gov.ListGovernParam(module, blockHash)

--- a/x/gov/gov.go
+++ b/x/gov/gov.go
@@ -330,7 +330,7 @@ func checkVerifier(from common.Address, nodeID discover.NodeID, blockHash common
 		return err
 	}
 
-	xcom.PrintObject("checkVerifier", verifierList)
+	//xcom.PrintObject("checkVerifier", verifierList)
 
 	for _, verifier := range verifierList {
 		if verifier != nil && verifier.NodeId == nodeID {

--- a/x/gov/gov_err.go
+++ b/x/gov/gov_err.go
@@ -36,5 +36,5 @@ var (
 	UnsupportedGovernParam            = common.NewBizError(302031, "unsupported govern parameter")
 	VotingParamProposalExist          = common.NewBizError(302032, "another param proposal at voting stage")
 	GovernParamValueError             = common.NewBizError(302033, "govern parameter value error")
-	ParamProposalIsSameValue          = common.NewBizError(302033, "the new value of the parameter proposal is the same as the old value")
+	ParamProposalIsSameValue          = common.NewBizError(302034, "the new value of the parameter proposal is the same as the old value")
 )

--- a/x/gov/proposals.go
+++ b/x/gov/proposals.go
@@ -398,18 +398,6 @@ func (pp *ParamProposal) Verify(submitBlock uint64, blockHash common.Hash, state
 		return err
 	}
 
-	if paramVerifier, ok := ParamVerifierMap[pp.Module+"/"+pp.Name]; ok {
-		if err := paramVerifier(submitBlock, blockHash, pp.NewValue); err != nil {
-			return err
-		}
-	} else {
-		return GovernParamValueError
-	}
-
-	epochRounds := xutil.CalcEpochRounds(xcom.ParamProposalVote_DurationSeconds())
-	endVotingBlock := xutil.CalEndVotingBlockForParamProposal(submitBlock, epochRounds)
-	pp.EndVotingBlock = endVotingBlock
-
 	param, err := FindGovernParam(pp.Module, pp.Name, blockHash)
 	if err != nil {
 		log.Error("find govern parameter error", "err", err)
@@ -418,6 +406,14 @@ func (pp *ParamProposal) Verify(submitBlock uint64, blockHash common.Hash, state
 		return UnsupportedGovernParam
 	} else if param.ParamValue.Value == pp.NewValue {
 		return ParamProposalIsSameValue
+	}
+
+	if paramVerifier, ok := ParamVerifierMap[pp.Module+"/"+pp.Name]; ok {
+		if err := paramVerifier(submitBlock, blockHash, pp.NewValue); err != nil {
+			return err
+		}
+	} else {
+		return UnsupportedGovernParam
 	}
 
 	if exist, err := FindVotingProposal(blockHash, state, Param, Version); err != nil {
@@ -430,6 +426,11 @@ func (pp *ParamProposal) Verify(submitBlock uint64, blockHash common.Hash, state
 			return VotingVersionProposalExist
 		}
 	}
+
+	epochRounds := xutil.CalcEpochRounds(xcom.ParamProposalVote_DurationSeconds())
+	endVotingBlock := xutil.CalEndVotingBlockForParamProposal(submitBlock, epochRounds)
+	pp.EndVotingBlock = endVotingBlock
+
 	return nil
 }
 


### PR DESCRIPTION
1. modify ParamProposalIsSameValue error code from 302033 to 302034
2. add ParamProposalIsSameValue error
3. refactor ParamProposal.Verify()
4. remove xcom.PrintObject()
5. add debug message to listGovernParam and getGovernParamValue