### PR TITLE
Feature/bump version to 0.7.4

### DIFF
--- a/core/vm/gov_contract_test.go
+++ b/core/vm/gov_contract_test.go
@@ -434,6 +434,30 @@ func TestGovContract_SubmitParam_thenSubmitVersionFailed(t *testing.T) {
 	runGovContract(false, gc, buildSubmitVersionInput(), t, gov.VotingParamProposalExist)
 }
 
+func TestGovContract_SubmitParam_GetAccuVerifiers(t *testing.T) {
+	chain := setup(t)
+	defer clear(chain, t)
+
+	value, err := gov.GetGovernParamValue(paramModule, paramName, chain.CurrentHeader().Number.Uint64(), chain.CurrentHeader().Hash())
+	if err != nil {
+		t.Errorf("%s", err)
+	} else {
+		assert.Equal(t, "25", value)
+	}
+
+	//submit a proposal and vote for it.
+	runGovContract(false, gc, buildSubmitParam(nodeIdArr[1], "pipid3", paramModule, paramName, "30"), t)
+	//runGovContract(false, gc, buildSubmitTextInput(), t)
+	commit_sndb(chain)
+
+	prepair_sndb(chain, txHashArr[2])
+	allVote(chain, t, txHashArr[1])
+	commit_sndb(chain)
+
+	runGovContract(false, gc, buildGetAccuVerifiersCountInput(defaultProposalID, chain.CurrentHeader().Hash()), t)
+
+}
+
 func TestGovContract_SubmitParam_Pass(t *testing.T) {
 	chain := setup(t)
 	defer clear(chain, t)
@@ -453,6 +477,8 @@ func TestGovContract_SubmitParam_Pass(t *testing.T) {
 	prepair_sndb(chain, txHashArr[2])
 	allVote(chain, t, txHashArr[1])
 	commit_sndb(chain)
+
+	runGovContract(false, gc, buildGetAccuVerifiersCountInput(defaultProposalID, chain.CurrentHeader().Hash()), t)
 
 	p, err := gov.GetProposal(defaultProposalID, chain.StateDB)
 	if err != nil {

--- a/x/plugin/gov_plugin.go
+++ b/x/plugin/gov_plugin.go
@@ -435,10 +435,12 @@ func tally(proposalType gov.ProposalType, proposalID common.Hash, blockHash comm
 		return false, err
 	}
 
-	if err := gov.ClearVoteValue(proposalID, blockHash); err != nil {
+	// for now, do not remove these data.
+	// If really want to remove these data, please confirmed with PlatON Explorer Project
+	/*if err := gov.ClearVoteValue(proposalID, blockHash); err != nil {
 		log.Error("clear vote value failed", "proposalID", proposalID, "blockHash", blockHash, "err", err)
 		return false, err
-	}
+	}*/
 
 	log.Debug("proposal tally result", "proposalID", proposalID, "tallyResult", tallyResult, "verifierList", verifierList)
 	return status == gov.Pass, nil


### PR DESCRIPTION
1. for now, do not remove voting values after a proposal is end-voting.
2. add unit test for getAccuVerifiers()