### PR TITLE
for now, do not remove voting values after a proposal is end-voting.

### DIFF
--- a/x/plugin/gov_plugin.go
+++ b/x/plugin/gov_plugin.go
@@ -279,10 +279,12 @@ func tallyVersion(proposal *gov.VersionProposal, blockHash common.Hash, blockNum
 		return err
 	}
 
-	if err := gov.ClearVoteValue(proposalID, blockHash); err != nil {
+	// for now, do not remove these data.
+	// If really want to remove these data, please confirmed with PlatON Explorer Project
+	/*if err := gov.ClearVoteValue(proposalID, blockHash); err != nil {
 		log.Error("clear vote value failed", "proposalID", proposalID, "blockHash", blockHash, "err", err)
 		return err
-	}
+	}*/
 
 	log.Info("version proposal tally result", "proposalID", proposalID, "tallyResult", tallyResult, "verifierList", verifierList)
 	return nil


### PR DESCRIPTION
for now, do not remove voting values after a proposal is end-voting.