### PR TITLE
Optimize the storage of the blockchain

### DIFF
--- a/cmd/platon/main.go
+++ b/cmd/platon/main.go
@@ -165,6 +165,14 @@ var (
 		utils.CbftBlsPriKeyFileFlag,
 		utils.CbftBlacklistDeadlineFlag,
 	}
+
+	dbFlags = []cli.Flag{
+		utils.DBNoGCFlag,
+		utils.DBGCIntervalFlag,
+		utils.DBGCTimeoutFlag,
+		utils.DBGCMptFlag,
+		utils.DBGCBlockFlag,
+	}
 )
 
 func init() {
@@ -212,6 +220,7 @@ func init() {
 	//app.Flags = append(app.Flags, vcFlags...)
 	// for cbft
 	app.Flags = append(app.Flags, cbftFlags...)
+	app.Flags = append(app.Flags, dbFlags...)
 
 	app.Before = func(ctx *cli.Context) error {
 		runtime.GOMAXPROCS(runtime.NumCPU())

--- a/cmd/platon/usage.go
+++ b/cmd/platon/usage.go
@@ -243,6 +243,16 @@ var AppHelpFlagGroups = []flagGroup{
 		},
 	},
 	{
+		Name: "DB",
+		Flags: []cli.Flag{
+			utils.DBNoGCFlag,
+			utils.DBGCIntervalFlag,
+			utils.DBGCTimeoutFlag,
+			utils.DBGCMptFlag,
+			utils.DBGCBlockFlag,
+		},
+	},
+	{
 		Name: "MISC",
 	},
 }

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -595,6 +595,30 @@ var (
 		Usage: "Blacklist effective time. uint:minute",
 		Value: "60",
 	}
+
+	DBNoGCFlag = cli.BoolFlag{
+		Name:  "db.nogc",
+		Usage: "Disables database garbage collection",
+	}
+	DBGCIntervalFlag = cli.Uint64Flag{
+		Name:  "db.gc_interval",
+		Usage: "Block interval for garbage collection",
+		Value: eth.DefaultConfig.DBGCInterval,
+	}
+	DBGCTimeoutFlag = cli.DurationFlag{
+		Name:  "db.gc_timeout",
+		Usage: "Maximum time for database garbage collection",
+		Value: eth.DefaultConfig.DBGCTimeout,
+	}
+	DBGCMptFlag = cli.BoolFlag{
+		Name:  "db.gc_mpt",
+		Usage: "Enables database garbage collection MPT",
+	}
+	DBGCBlockFlag = cli.Uint64Flag{
+		Name:  "db.gc_block",
+		Usage: "Number of cache block states, default 10",
+		Value: eth.DefaultConfig.DBGCBlock,
+	}
 )
 
 // MakeDataDir retrieves the currently requested data directory, terminating
@@ -1165,6 +1189,25 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *eth.Config) {
 	// TODO(fjl): move trie cache generations into config
 	if gen := ctx.GlobalInt(TrieCacheGenFlag.Name); gen > 0 {
 		state.MaxTrieCacheGen = uint16(gen)
+	}
+
+	if ctx.GlobalIsSet(DBNoGCFlag.Name) {
+		cfg.DBDisabledGC = ctx.GlobalBool(DBNoGCFlag.Name)
+	}
+	if ctx.GlobalIsSet(DBGCIntervalFlag.Name) {
+		cfg.DBGCInterval = ctx.GlobalUint64(DBGCIntervalFlag.Name)
+	}
+	if ctx.GlobalIsSet(DBGCTimeoutFlag.Name) {
+		cfg.DBGCTimeout = ctx.GlobalDuration(DBGCTimeoutFlag.Name)
+	}
+	if ctx.GlobalIsSet(DBGCMptFlag.Name) {
+		cfg.DBGCMpt = ctx.GlobalBool(DBGCMptFlag.Name)
+	}
+	if ctx.GlobalIsSet(DBGCBlockFlag.Name) {
+		b := ctx.GlobalUint64(DBGCBlockFlag.Name)
+		if b > 0 {
+			cfg.DBGCBlock = b
+		}
 	}
 }
 

--- a/common/atomic_bool.go
+++ b/common/atomic_bool.go
@@ -1,0 +1,42 @@
+package common
+
+import "sync/atomic"
+
+// noCopy may be embedded into structs which must not be copied
+// after the first use.
+//
+// See https://github.com/golang/go/issues/8005#issuecomment-190753527
+// for details.
+type noCopy struct{}
+
+// Lock is a no-op used by -copylocks checker from `go vet`.
+func (*noCopy) Lock() {}
+
+// AtomicBool is a wrapper around uint32 for usage as a boolean value with
+// atomic access.
+type AtomicBool struct {
+	_noCopy noCopy
+	value   uint32
+}
+
+// IsSet returns wether the current boolean value is true.
+func (ab *AtomicBool) IsSet() bool {
+	return atomic.LoadUint32(&ab.value) > 0
+}
+
+// Set sets the value of the bool regardless of ther previous value.
+func (ab *AtomicBool) Set(value bool) {
+	if value {
+		atomic.StoreUint32(&ab.value, 1)
+	} else {
+		atomic.StoreUint32(&ab.value, 0)
+	}
+}
+
+// TrySet sets the value of the bool and returns wether the value changed.
+func (ab *AtomicBool) TrySet(value bool) bool {
+	if value {
+		return atomic.SwapUint32(&ab.value, 1) == 0
+	}
+	return atomic.SwapUint32(&ab.value, 0) > 0
+}

--- a/common/atomic_bool_test.go
+++ b/common/atomic_bool_test.go
@@ -1,0 +1,37 @@
+package common
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAtomicBool(t *testing.T) {
+	var ab AtomicBool
+	assert.False(t, ab.IsSet(), "Expected value to be false")
+
+	ab.Set(true)
+	assert.False(t, ab.value != 1, "Set(true) did not set value to 1")
+	assert.True(t, ab.IsSet(), "Expected value to be true")
+
+	ab.Set(true)
+	assert.True(t, ab.IsSet(), "Expected value to be true")
+
+	ab.Set(false)
+	assert.False(t, ab.value != 0, "Set(false) did not set value to 0")
+	assert.False(t, ab.IsSet(), "Expected value to be false")
+
+	ab.Set(false)
+	assert.False(t, ab.IsSet(), "Expected value to be false")
+	assert.False(t, ab.TrySet(false), "Expected TrySet(false) to fail")
+
+	assert.True(t, ab.TrySet(true), "Exepected TrySet(true) to succed")
+	assert.True(t, ab.IsSet(), "Expected value to be true")
+
+	ab.Set(true)
+	assert.True(t, ab.IsSet(), "Expected value to be true")
+	assert.False(t, ab.TrySet(true), "Expected TrySet(true) to fail")
+	assert.True(t, ab.TrySet(false), "Exptected TrySet(false) to succeed")
+	assert.False(t, ab.IsSet(), "Expected value to be false")
+	ab._noCopy.Lock()
+}

--- a/consensus/cbft/cbft.go
+++ b/consensus/cbft/cbft.go
@@ -543,7 +543,7 @@ func (cbft *Cbft) handleConsensusMsg(info *ctypes.MsgInfo) error {
 	}
 
 	if err != nil {
-		cbft.log.Error("Handle msg Failed", "error", err, "type", reflect.TypeOf(msg), "peer", id, "err", err, "peerMsgCh", len(cbft.peerMsgCh))
+		cbft.log.Debug("Handle msg Failed", "error", err, "type", reflect.TypeOf(msg), "peer", id, "err", err, "peerMsgCh", len(cbft.peerMsgCh))
 	}
 	return err
 }

--- a/consensus/cbft/cbft.go
+++ b/consensus/cbft/cbft.go
@@ -995,11 +995,7 @@ func (cbft *Cbft) FastSyncCommitHead(block *types.Block) error {
 			return
 		}
 
-		vEpoch := qc.Epoch
-		if cbft.validatorPool.ShouldSwitch(block.NumberU64()) {
-			vEpoch += 1
-		}
-		err = cbft.validatorPool.Update(block.NumberU64(), vEpoch, cbft.eventMux)
+		cbft.validatorPool.Reset(block.NumberU64(), qc.Epoch)
 
 		cbft.blockTree.Reset(block, qc)
 		cbft.changeView(qc.Epoch, qc.ViewNumber, block, qc, nil)

--- a/consensus/cbft/validator/validator.go
+++ b/consensus/cbft/validator/validator.go
@@ -273,6 +273,25 @@ func NewValidatorPool(agency consensus.Agency, blockNumber uint64, epoch uint64,
 	return pool
 }
 
+// Reset reset validator pool.
+func (vp *ValidatorPool) Reset(blockNumber uint64, epoch uint64) {
+	if vp.agency.GetLastNumber(blockNumber) == blockNumber {
+		vp.prevValidators, _ = vp.agency.GetValidator(blockNumber)
+		vp.currentValidators, _ = vp.agency.GetValidator(NextRound(blockNumber))
+		vp.lastNumber = vp.agency.GetLastNumber(NextRound(blockNumber))
+		vp.epoch = epoch + 1
+	} else {
+		vp.currentValidators, _ = vp.agency.GetValidator(blockNumber)
+		vp.prevValidators = vp.currentValidators
+		vp.lastNumber = vp.agency.GetLastNumber(blockNumber)
+		vp.epoch = epoch
+	}
+	if vp.currentValidators.ValidBlockNumber > 0 {
+		vp.switchPoint = vp.currentValidators.ValidBlockNumber - 1
+	}
+	log.Debug("Update validator", "validators", vp.currentValidators.String(), "switchpoint", vp.switchPoint, "epoch", vp.epoch, "lastNumber", vp.lastNumber)
+}
+
 // ShouldSwitch check if should switch validators at the moment.
 func (vp *ValidatorPool) ShouldSwitch(blockNumber uint64) bool {
 	if blockNumber == 0 {

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -214,7 +214,7 @@ func NewBlockChain(db ethdb.Database, cacheConfig *CacheConfig, chainConfig *par
 	//	}
 	//}
 
-	log.Debug("DB config", "DBDisabledGC", bc.cacheConfig.DBDisabledGC, "DBGCInterval", bc.cacheConfig.DBGCInterval, "DBGCTimeout", bc.cacheConfig.DBGCTimeout)
+	log.Debug("DB config", "DBDisabledGC", bc.cacheConfig.DBDisabledGC, "DBGCInterval", bc.cacheConfig.DBGCInterval, "DBGCTimeout", bc.cacheConfig.DBGCTimeout, "DBGCMpt", bc.cacheConfig.DBGCMpt)
 	bc.cleaner = NewCleaner(bc, bc.cacheConfig.DBGCInterval, bc.cacheConfig.DBGCTimeout, bc.cacheConfig.DBGCMpt)
 
 	// Take ownership of this particular state

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -826,7 +826,7 @@ func (bc *BlockChain) InsertReceiptChain(blockChain types.Blocks, receiptChain [
 		batch = bc.db.NewBatch()
 	)
 	for i, block := range blockChain {
-		receipts := receiptChain[i]
+		//receipts := receiptChain[i]
 		// Short circuit insertion if shutting down or processing failed
 		if atomic.LoadInt32(&bc.procInterrupt) == 1 {
 			return 0, nil
@@ -841,12 +841,12 @@ func (bc *BlockChain) InsertReceiptChain(blockChain types.Blocks, receiptChain [
 			continue
 		}
 		// Compute all the non-consensus fields of the receipts
-		if err := SetReceiptsData(bc.chainConfig, block, receipts); err != nil {
-			return i, fmt.Errorf("failed to set receipts data: %v", err)
-		}
+		//if err := SetReceiptsData(bc.chainConfig, block, receipts); err != nil {
+		//	return i, fmt.Errorf("failed to set receipts data: %v", err)
+		//}
 		// Write all the data out into the database
 		rawdb.WriteBody(batch, block.Hash(), block.NumberU64(), block.Body())
-		rawdb.WriteReceipts(batch, block.Hash(), block.NumberU64(), receipts)
+		//rawdb.WriteReceipts(batch, block.Hash(), block.NumberU64(), receipts)
 		rawdb.WriteTxLookupEntries(batch, block)
 
 		stats.processed++

--- a/core/blockchain_cache.go
+++ b/core/blockchain_cache.go
@@ -270,7 +270,9 @@ func (bcc *BlockChainCache) Execute(block *types.Block, parent *types.Block) err
 		return nil
 	}
 	log.Debug("Start execute block", "hash", block.Hash(), "number", block.Number(), "sealHash", block.Header().SealHash())
+	start := time.Now()
 	state, err := bcc.MakeStateDB(parent)
+	elapse := time.Since(start)
 	if err != nil {
 		return errors.New("execute block error")
 	}
@@ -279,7 +281,7 @@ func (bcc *BlockChainCache) Execute(block *types.Block, parent *types.Block) err
 	//to execute
 	receipts, err := bcc.ProcessDirectly(block, state, parent)
 	log.Debug("Execute block", "number", block.Number(), "hash", block.Hash(),
-		"parentNumber", parent.Number(), "parentHash", parent.Hash(), "duration", time.Since(t), "err", err)
+		"parentNumber", parent.Number(), "parentHash", parent.Hash(), "duration", time.Since(t), "makeState", elapse, "err", err)
 	if err == nil {
 		//save the receipts and state to consensusCache
 		sealHash := block.Header().SealHash()

--- a/core/blockchain_clean.go
+++ b/core/blockchain_clean.go
@@ -1,0 +1,197 @@
+package core
+
+import (
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/PlatONnetwork/PlatON-Go/common"
+	"github.com/PlatONnetwork/PlatON-Go/core/rawdb"
+	"github.com/PlatONnetwork/PlatON-Go/ethdb"
+	"github.com/PlatONnetwork/PlatON-Go/event"
+	"github.com/PlatONnetwork/PlatON-Go/log"
+)
+
+var (
+	lastNumberKey = []byte("last-clean-number")
+
+	minCleanTimeout = time.Minute
+
+	cleanDistance uint64 = 1
+)
+
+type CleanupEvent struct{}
+
+type CleanBatch struct {
+	lock  sync.Mutex
+	batch ethdb.Batch
+}
+
+func (cb *CleanBatch) Delete(key []byte) error {
+	cb.lock.Lock()
+	defer cb.lock.Unlock()
+	return cb.batch.Delete(key)
+}
+
+func (cb *CleanBatch) ValueSize() int {
+	cb.lock.Lock()
+	defer cb.lock.Unlock()
+	return cb.batch.ValueSize()
+}
+
+func (cb *CleanBatch) WriteAndRest() error {
+	cb.lock.Lock()
+	defer cb.lock.Unlock()
+	if err := cb.batch.Write(); err != nil {
+		cb.batch.Reset()
+		return err
+	}
+	cb.batch.Reset()
+	return nil
+}
+
+type Cleaner struct {
+	stopped      common.AtomicBool
+	cleaning     common.AtomicBool
+	interval     uint64
+	lastNumber   uint64
+	cleanTimeout time.Duration
+	gcMpt        bool
+
+	wg        sync.WaitGroup
+	exit      chan struct{}
+	cleanFeed event.Feed
+	scope     event.SubscriptionScope
+	cleanCh   chan *CleanupEvent
+
+	batch      CleanBatch
+	lock       sync.RWMutex
+	blockchain *BlockChain
+}
+
+func NewCleaner(blockchain *BlockChain, interval uint64, cleanTimeout time.Duration, gcMpt bool) *Cleaner {
+	c := &Cleaner{
+		interval:     interval,
+		lastNumber:   0,
+		cleanTimeout: cleanTimeout,
+		gcMpt:        gcMpt,
+		exit:         make(chan struct{}),
+		cleanCh:      make(chan *CleanupEvent, 1),
+		batch: CleanBatch{
+			batch: blockchain.db.NewBatch(),
+		},
+		blockchain: blockchain,
+	}
+
+	if c.cleanTimeout < minCleanTimeout {
+		c.cleanTimeout = minCleanTimeout
+	}
+
+	buf, err := c.blockchain.db.Get(lastNumberKey)
+	if err == nil && len(buf) > 0 {
+		lastNumber := common.BytesToUint64(buf)
+		atomic.StoreUint64(&c.lastNumber, lastNumber)
+	}
+
+	c.scope.Track(c.cleanFeed.Subscribe(c.cleanCh))
+	c.wg.Add(1)
+	go c.loop()
+	return c
+}
+
+func (c *Cleaner) Stop() {
+	if c.stopped.IsSet() {
+		return
+	}
+
+	c.scope.Close()
+	close(c.exit)
+
+	c.stopped.Set(true)
+	c.wg.Wait()
+}
+
+func (c *Cleaner) Cleanup() {
+	if c.cleaning.IsSet() {
+		return
+	}
+	c.cleaning.Set(true)
+	c.cleanFeed.Send(&CleanupEvent{})
+}
+
+func (c *Cleaner) NeedCleanup() bool {
+	lastNumber := atomic.LoadUint64(&c.lastNumber)
+	return c.blockchain.CurrentBlock().NumberU64()-lastNumber >= 2*c.interval && !c.cleaning.IsSet()
+}
+
+func (c *Cleaner) loop() {
+	defer c.wg.Done()
+
+	for {
+		select {
+		case <-c.cleanCh:
+			c.cleanup()
+		case <-c.exit:
+			return
+		}
+	}
+}
+
+func (c *Cleaner) cleanup() {
+	defer c.cleaning.Set(false)
+
+	db, ok := c.blockchain.db.(*ethdb.LDBDatabase)
+	if !ok {
+		log.Warn("The database not a leveldb, discard cleanup operation")
+		return
+	}
+
+	lastNumber := atomic.LoadUint64(&c.lastNumber)
+	currentBlock := c.blockchain.CurrentBlock()
+	if currentBlock.NumberU64()-lastNumber <= cleanDistance {
+		return
+	}
+
+	var (
+		receipts = 0
+		txs      = 0
+		keys     = 0
+	)
+
+	t := time.Now()
+	log.Info("Start cleanup database", "interval", c.interval, "cleanTimeout", c.cleanTimeout, "gcMpt", c.gcMpt, "lastNumber", atomic.LoadUint64(&c.lastNumber), "number", currentBlock.NumberU64(), "hash", currentBlock.Hash())
+	defer func() {
+		log.Info("Finish cleanup database", "lastNumber", atomic.LoadUint64(&c.lastNumber), "receipts", receipts, "txs", txs, "keys", keys, "elapsed", time.Since(t))
+	}()
+
+	if currentBlock.NumberU64()-c.lastNumber >= 2*c.interval {
+		number := lastNumber + 1
+		for ; number <= currentBlock.NumberU64()-c.interval; number++ {
+			block := c.blockchain.GetBlockByNumber(number)
+			if block == nil {
+				log.Error("Found bad header", "number", number)
+				return
+			}
+
+			rawdb.DeleteReceipts(db, block.Hash(), block.NumberU64())
+
+			batch := c.blockchain.db.NewBatch()
+			for _, tx := range block.Transactions() {
+				txs++
+				rawdb.DeleteTxLookupEntry(batch, tx.Hash())
+			}
+			batch.Write()
+
+			receipts++
+
+			if time.Since(t) >= c.cleanTimeout || c.stopped.IsSet() {
+				atomic.StoreUint64(&c.lastNumber, number)
+				db.Put(lastNumberKey, common.Uint64ToBytes(number))
+				return
+			}
+		}
+		atomic.StoreUint64(&c.lastNumber, number-1)
+		db.Put(lastNumberKey, common.Uint64ToBytes(number-1))
+	}
+
+}

--- a/core/blockchain_clean_test.go
+++ b/core/blockchain_clean_test.go
@@ -1,0 +1,131 @@
+package core
+
+import (
+	"crypto/rand"
+	"fmt"
+	"io/ioutil"
+	"math/big"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/PlatONnetwork/PlatON-Go/crypto"
+
+	"github.com/PlatONnetwork/PlatON-Go/consensus"
+	"github.com/PlatONnetwork/PlatON-Go/core/snapshotdb"
+	"github.com/PlatONnetwork/PlatON-Go/ethdb"
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	testKey, _  = crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
+	testAddress = crypto.PubkeyToAddress(testKey.PublicKey)
+
+	securePreifx = []byte("secure-key-")
+)
+
+func randBytes(n int) []byte {
+	r := make([]byte, n)
+	rand.Read(r)
+	return r
+}
+
+func newBlockChainForTesting(db ethdb.Database) (*BlockChain, error) {
+	buf, err := ioutil.ReadFile("../eth/downloader/testdata/platon.json")
+	if err != nil {
+		return nil, err
+	}
+
+	var gen Genesis
+	if err := gen.UnmarshalJSON(buf); err != nil {
+		return nil, err
+	}
+
+	gen.Alloc[testAddress] = GenesisAccount{
+		Code:    nil,
+		Storage: nil,
+		Balance: big.NewInt(10000000000),
+		Nonce:   0,
+	}
+
+	block, _ := gen.Commit(db, snapshotdb.Instance())
+
+	return GenerateBlockChain(gen.Config, block, new(consensus.BftMock), db, 200, func(i int, block *BlockGen) {
+		block.statedb.SetState(testAddress, []byte(fmt.Sprintf("abc_%d", i+1)), []byte(fmt.Sprintf("abccccccc_%d", i+1)))
+	}), nil
+}
+
+func TestCleaner(t *testing.T) {
+	tmpDir, err := ioutil.TempDir("", "platon")
+	assert.Nil(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	db, err := ethdb.NewLDBDatabase(tmpDir, 100, 1024)
+	assert.Nil(t, err)
+
+	blockchain, err := newBlockChainForTesting(db)
+	assert.Nil(t, err)
+	assert.NotNil(t, blockchain)
+
+	cleaner := NewCleaner(blockchain, 100, time.Minute, false)
+	cleaner.lastNumber = 0
+	assert.NotNil(t, cleaner)
+	assert.True(t, cleaner.NeedCleanup())
+	cleaner.interval = 200
+	assert.False(t, cleaner.NeedCleanup())
+
+	cleaner.lastNumber = 0
+	cleaner.interval = 100
+	cleaner.cleanTimeout = time.Nanosecond
+	cleaner.Cleanup()
+	time.Sleep(100 * time.Millisecond)
+	//fmt.Println(cleaner.lastNumber)
+	assert.True(t, cleaner.lastNumber == 1)
+
+	cleaner.lastNumber = 0
+	cleaner.cleanTimeout = time.Minute
+	cleaner.Cleanup()
+	assert.True(t, cleaner.cleaning.IsSet())
+	time.Sleep(500 * time.Millisecond) // Waiting cleanup finish
+	assert.True(t, cleaner.lastNumber == 100)
+	assert.False(t, cleaner.cleaning.IsSet())
+
+	cleaner.gcMpt = true
+	cleaner.lastNumber = 0
+	cleaner.Cleanup()
+	time.Sleep(50 * time.Millisecond)
+	assert.True(t, cleaner.lastNumber == 100)
+
+	block := blockchain.GetBlockByNumber(188)
+	_, err = blockchain.StateAt(block.Root())
+	assert.Nil(t, err)
+
+	block = blockchain.GetBlockByNumber(200)
+	statedb, _ := blockchain.StateAt(block.Root())
+	assert.NotNil(t, statedb)
+	buf := statedb.GetState(testAddress, []byte(fmt.Sprintf("abc_%d", block.NumberU64())))
+	assert.Equal(t, string(buf), fmt.Sprintf("abccccccc_%d", block.NumberU64()))
+
+	cleaner.Stop()
+
+	cleaner = NewCleaner(blockchain, 200, time.Minute, false)
+	assert.Equal(t, cleaner.lastNumber, uint64(100))
+}
+
+func TestStopCleaner(t *testing.T) {
+	tmpDir, _ := ioutil.TempDir("", "platon")
+	defer os.RemoveAll(tmpDir)
+
+	db, err := ethdb.NewLDBDatabase(tmpDir, 100, 1024)
+	assert.Nil(t, err)
+
+	blockchain, err := newBlockChainForTesting(db)
+	assert.Nil(t, err)
+
+	cleaner := NewCleaner(blockchain, 100, time.Minute, false)
+	assert.False(t, cleaner.stopped.IsSet())
+	cleaner.Cleanup()
+	time.Sleep(time.Millisecond)
+	cleaner.Stop()
+	assert.True(t, cleaner.stopped.IsSet())
+}

--- a/core/chain_makers.go
+++ b/core/chain_makers.go
@@ -189,7 +189,7 @@ func GenerateChain(config *params.ChainConfig, parent *types.Block, engine conse
 			if err != nil {
 				panic(fmt.Sprintf("state write error: %v", err))
 			}
-			if err := statedb.Database().TrieDB().Commit(root, false); err != nil {
+			if err := statedb.Database().TrieDB().Commit(root, false, true); err != nil {
 				panic(fmt.Sprintf("trie write error: %v", err))
 			}
 			return block, b.receipts
@@ -222,6 +222,8 @@ func GenerateBlockChain2(config *params.ChainConfig, parent *types.Block, engine
 		MaxFutureBlocks: 256,
 		BadBlockLimit:   10,
 		TriesInMemory:   128,
+		DBGCInterval:    86400,
+		DBGCTimeout:     time.Minute,
 	}
 	blockchain, _ := NewBlockChain(db, cacheConfig, config, engine, vm.Config{}, nil)
 	blocks, receipts := make(types.Blocks, n), make([]types.Receipts, n)
@@ -274,6 +276,8 @@ func GenerateBlockChain(config *params.ChainConfig, parent *types.Block, engine 
 		MaxFutureBlocks: 256,
 		BadBlockLimit:   10,
 		TriesInMemory:   128,
+		DBGCInterval:    86400,
+		DBGCTimeout:     time.Minute,
 	}
 	blockchain, _ := NewBlockChain(db, cacheConfig, config, engine, vm.Config{}, nil)
 	blocks, receipts := make(types.Blocks, n), make([]types.Receipts, n)

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -332,7 +332,7 @@ func (g *Genesis) ToBlock(db ethdb.Database, sdb snapshotdb.DB) *types.Block {
 	if _, err := statedb.Commit(false); nil != err {
 		panic("Failed to commit genesis stateDB: " + err.Error())
 	}
-	if err := statedb.Database().TrieDB().Commit(root, true); nil != err {
+	if err := statedb.Database().TrieDB().Commit(root, true, true); nil != err {
 		panic("Failed to trieDB commit by genesis: " + err.Error())
 	}
 

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -120,7 +120,7 @@ func New(root common.Hash, db Database) (*StateDB, error) {
 func (self *StateDB) NewStateDB() *StateDB {
 	stateDB := &StateDB{
 		db:                 self.db,
-		trie:               self.db.CopyTrie(self.trie),
+		trie:               self.db.NewTrie(self.trie),
 		stateObjects:       make(map[common.Address]*stateObject),
 		stateObjectsDirty:  make(map[common.Address]struct{}),
 		logs:               make(map[common.Hash][]*types.Log),

--- a/core/state/statedb_test.go
+++ b/core/state/statedb_test.go
@@ -125,8 +125,8 @@ func TestNewStateDBAndCopy(t *testing.T) {
 	if _, err := s1c.Commit(false); err != nil {
 		t.Fatalf("failed to commit s1c state: %v", err)
 	}
-	assert.Nil(t, s1.db.TrieDB().Commit(s1.Root(), false))
-	assert.Nil(t, s1c.db.TrieDB().Commit(s1c.Root(), false))
+	assert.Nil(t, s1.db.TrieDB().Commit(s1.Root(), false, true))
+	assert.Nil(t, s1c.db.TrieDB().Commit(s1c.Root(), false, true))
 
 	// test new statedb
 	st2 := s1.NewStateDB()
@@ -212,8 +212,8 @@ func TestNewStateDBAndCopy(t *testing.T) {
 		}
 	}
 
-	assert.Nil(t, s3.db.TrieDB().Commit(s1.Root(), false))
-	assert.Nil(t, s1cc.db.TrieDB().Commit(s1cc.Root(), false))
+	assert.Nil(t, s3.db.TrieDB().Commit(s1.Root(), false, true))
+	assert.Nil(t, s1cc.db.TrieDB().Commit(s1cc.Root(), false, true))
 
 	for _, k := range db.Keys() {
 		if _, err := dbc.Get(k); err != nil {
@@ -256,7 +256,7 @@ func TestStateStorageValueCommit(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := s1.db.TrieDB().Commit(root, true); err != nil {
+	if err := s1.db.TrieDB().Commit(root, true, true); err != nil {
 		t.Fatal(err)
 	}
 	s2, err := New(root, NewDatabase(db))
@@ -287,7 +287,7 @@ func TestStateStorageValueDelete(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := s1.db.TrieDB().Commit(root, true); err != nil {
+	if err := s1.db.TrieDB().Commit(root, true, true); err != nil {
 		t.Fatal(err)
 	}
 
@@ -329,7 +329,7 @@ func TestStateStorageRevert(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	s1.db.TrieDB().Commit(root, true)
+	s1.db.TrieDB().Commit(root, true, true)
 
 	assert.Equal(t, value1, s1.GetState(addr, key1))
 	obj := s1.getStateObject(addr)

--- a/eth/api.go
+++ b/eth/api.go
@@ -190,6 +190,16 @@ func (api *PublicDebugAPI) DumpBlock(blockNr rpc.BlockNumber) (state.Dump, error
 	return stateDb.RawDump(), nil
 }
 
+// EnableDBGC enable database garbage collection.
+func (api *PublicDebugAPI) EnableDBGC() {
+	api.eth.BlockChain().EnableDBGC()
+}
+
+// DisableDBGC disable database garbage collection.
+func (api *PublicDebugAPI) DisableDBGC() {
+	api.eth.BlockChain().DisableDBGC()
+}
+
 // PrivateDebugAPI is the collection of Ethereum full node APIs exposed over
 // the private debugging endpoint.
 type PrivateDebugAPI struct {

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -173,7 +173,8 @@ func New(ctx *node.ServiceContext, config *Config) (*Ethereum, error) {
 		cacheConfig = &core.CacheConfig{Disabled: config.NoPruning, TrieNodeLimit: config.TrieCache, TrieTimeLimit: config.TrieTimeout,
 			BodyCacheLimit: config.BodyCacheLimit, BlockCacheLimit: config.BlockCacheLimit,
 			MaxFutureBlocks: config.MaxFutureBlocks, BadBlockLimit: config.BadBlockLimit,
-			TriesInMemory: config.TriesInMemory,
+			TriesInMemory: config.TriesInMemory, DBGCInterval: config.DBGCInterval, DBGCTimeout: config.DBGCTimeout,
+			DBGCMpt: config.DBGCMpt, DBGCBlock: config.DBGCBlock,
 		}
 
 		minningConfig = &core.MiningConfig{MiningLogAtDepth: config.MiningLogAtDepth, TxChanSize: config.TxChanSize,
@@ -184,6 +185,7 @@ func New(ctx *node.ServiceContext, config *Config) (*Ethereum, error) {
 			StaleThreshold: config.StaleThreshold, DefaultCommitRatio: config.DefaultCommitRatio,
 		}
 	)
+	cacheConfig.DBDisabledGC.Set(config.DBDisabledGC)
 
 	eth.blockchain, err = core.NewBlockChain(chainDb, cacheConfig, eth.chainConfig, eth.engine, vmConfig, eth.shouldPreserve)
 	if err != nil {

--- a/eth/config.go
+++ b/eth/config.go
@@ -58,6 +58,7 @@ var DefaultConfig = Config{
 	DBDisabledGC:  false,
 	DBGCInterval:  86400,
 	DBGCTimeout:   time.Minute,
+	DBGCMpt:       true,
 	DBGCBlock:     10,
 	MinerGasPrice: big.NewInt(params.GVon),
 	MinerRecommit: 3 * time.Second,

--- a/eth/config.go
+++ b/eth/config.go
@@ -55,6 +55,10 @@ var DefaultConfig = Config{
 	TrieTimeout:   60 * time.Minute,
 	MinerGasFloor: params.GenesisGasLimit,
 	//MinerGasCeil:  4000 * 21000 * 1.2,
+	DBDisabledGC:  false,
+	DBGCInterval:  86400,
+	DBGCTimeout:   time.Minute,
+	DBGCBlock:     10,
 	MinerGasPrice: big.NewInt(params.GVon),
 	MinerRecommit: 3 * time.Second,
 
@@ -121,6 +125,11 @@ type Config struct {
 	DatabaseCache      int
 	TrieCache          int
 	TrieTimeout        time.Duration
+	DBDisabledGC       bool
+	DBGCInterval       uint64
+	DBGCTimeout        time.Duration
+	DBGCMpt            bool
+	DBGCBlock          uint64
 
 	// Mining-related options
 	MinerExtraData []byte `toml:",omitempty"`

--- a/eth/downloader/queue.go
+++ b/eth/downloader/queue.go
@@ -341,10 +341,10 @@ func (q *queue) Schedule(headers []*types.Header, from uint64) []*types.Header {
 		q.blockTaskPool[hash] = header
 		q.blockTaskQueue.Push(header, -int64(header.Number.Uint64()))
 
-		if q.mode == FastSync {
-			q.receiptTaskPool[hash] = header
-			q.receiptTaskQueue.Push(header, -int64(header.Number.Uint64()))
-		}
+		//if q.mode == FastSync {
+		//	q.receiptTaskPool[hash] = header
+		//	q.receiptTaskQueue.Push(header, -int64(header.Number.Uint64()))
+		//}
 		inserts = append(inserts, header)
 		q.headerHead = hash
 		from++
@@ -517,9 +517,9 @@ func (q *queue) reserveHeaders(p *peerConnection, count int, taskPool map[common
 		}
 		if q.resultCache[index] == nil {
 			components := 1
-			if q.mode == FastSync {
-				components = 2
-			}
+			//if q.mode == FastSync {
+			//	components = 2
+			//}
 			q.resultCache[index] = &fetchResult{
 				Pending: components,
 				Hash:    hash,

--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -411,6 +411,14 @@ web3._extend({
 			name: 'economicConfig',
 			call: 'debug_economicConfig',
 		}),
+		new web3._extend.Method({
+			name: 'enableDBGC',
+			call: 'debug_enableDBGC',
+		}),
+		new web3._extend.Method({
+			name: 'disableDBGC',
+			call: 'debug_disableDBGC',
+		}),
 	],
 	properties: []
 });

--- a/light/postprocess.go
+++ b/light/postprocess.go
@@ -210,7 +210,7 @@ func (c *ChtIndexerBackend) Commit() error {
 	if err != nil {
 		return err
 	}
-	c.triedb.Commit(root, false)
+	c.triedb.Commit(root, false, true)
 
 	log.Info("Storing CHT", "section", c.section, "head", fmt.Sprintf("%064x", c.lastHash), "root", fmt.Sprintf("%064x", root))
 	StoreChtRoot(c.diskdb, c.section, c.lastHash, root)
@@ -374,7 +374,7 @@ func (b *BloomTrieIndexerBackend) Commit() error {
 	if err != nil {
 		return err
 	}
-	b.triedb.Commit(root, false)
+	b.triedb.Commit(root, false, true)
 
 	sectionHead := b.sectionHeads[b.bloomTrieRatio-1]
 	log.Info("Storing bloom trie", "section", b.section, "head", fmt.Sprintf("%064x", sectionHead), "root", fmt.Sprintf("%064x", root), "compression", float64(compSize)/float64(decompSize))

--- a/trie/database.go
+++ b/trie/database.go
@@ -235,7 +235,7 @@ func expandNode(hash hashNode, n node, cachegen uint16) node {
 			Key: compactToHex(n.Key),
 			Val: expandNode(nil, n.Val, cachegen),
 			flags: nodeFlag{
-				hash:  hash,
+				hash:  &hash,
 				gen:   cachegen,
 				dirty: &dirty,
 			},
@@ -245,7 +245,7 @@ func expandNode(hash hashNode, n node, cachegen uint16) node {
 		// Full nodes need child expansion
 		node := &fullNode{
 			flags: nodeFlag{
-				hash:  hash,
+				hash:  &hash,
 				gen:   cachegen,
 				dirty: &dirty,
 			},

--- a/trie/database.go
+++ b/trie/database.go
@@ -43,8 +43,8 @@ var (
 	memcacheCommitSizeMeter  = metrics.NewRegisteredMeter("trie/memcache/commit/size", nil)
 )
 
-// secureKeyPrefix is the database key prefix used to store trie node preimages.
-var secureKeyPrefix = []byte("secure-key-")
+// SecureKeyPrefix is the database key prefix used to store trie node preimages.
+var SecureKeyPrefix = []byte("secure-key-")
 
 // secureKeyLength is the length of the above prefix + 32byte hash.
 const secureKeyLength = 11 + 32
@@ -64,9 +64,10 @@ type DatabaseReader interface {
 type Database struct {
 	diskdb ethdb.Database // Persistent storage for matured trie nodes
 
-	nodes  map[common.Hash]*cachedNode // Data and references relationships of a node
-	oldest common.Hash                 // Oldest tracked node, flush-list head
-	newest common.Hash                 // Newest tracked node, flush-list tail
+	freshNodes map[common.Hash]struct{}
+	nodes      map[common.Hash]*cachedNode // Data and references relationships of a node
+	oldest     common.Hash                 // Oldest tracked node, flush-list head
+	newest     common.Hash                 // Newest tracked node, flush-list tail
 
 	preimages map[common.Hash][]byte // Preimages of nodes from the secure trie
 	seckeybuf [secureKeyLength]byte  // Ephemeral buffer for calculating preimage keys
@@ -268,9 +269,10 @@ func expandNode(hash hashNode, n node, cachegen uint16) node {
 // its written out to disk or garbage collected.
 func NewDatabase(diskdb ethdb.Database) *Database {
 	return &Database{
-		diskdb:    diskdb,
-		nodes:     map[common.Hash]*cachedNode{{}: {}},
-		preimages: make(map[common.Hash][]byte),
+		diskdb:     diskdb,
+		freshNodes: make(map[common.Hash]struct{}),
+		nodes:      map[common.Hash]*cachedNode{{}: {}},
+		preimages:  make(map[common.Hash][]byte),
 	}
 }
 
@@ -286,8 +288,15 @@ func (db *Database) DiskDB() DatabaseReader {
 func (db *Database) InsertBlob(hash common.Hash, blob []byte) {
 	db.lock.Lock()
 	defer db.lock.Unlock()
-
+	db.insertFreshNode(hash)
 	db.insert(hash, blob, rawNode(blob))
+}
+
+func (db *Database) insertFreshNode(hash common.Hash) {
+	db.freshNodes[hash] = struct{}{}
+}
+func (db *Database) resetFreshNode() {
+	db.freshNodes = make(map[common.Hash]struct{})
 }
 
 // insert inserts a collapsed trie node into the memory database. This method is
@@ -380,7 +389,7 @@ func (db *Database) Preimage(hash common.Hash) ([]byte, error) {
 		return preimage, nil
 	}
 	secureKey := make([]byte, secureKeyLength)
-	secureKey = append(secureKey[:0], secureKeyPrefix...)
+	secureKey = append(secureKey[:0], SecureKeyPrefix...)
 	secureKey = append(secureKey, hash[:]...)
 	// Content unavailable in memory, attempt to retrieve from disk
 	return db.diskdb.Get(secureKey)
@@ -390,7 +399,7 @@ func (db *Database) Preimage(hash common.Hash) ([]byte, error) {
 // buffer. The caller must not hold onto the return value because it will become
 // invalid on the next call.
 func (db *Database) secureKey(key []byte) []byte {
-	buf := append(db.seckeybuf[:0], secureKeyPrefix...)
+	buf := append(db.seckeybuf[:0], SecureKeyPrefix...)
 	buf = append(buf, key...)
 	return buf
 }
@@ -437,6 +446,41 @@ func (db *Database) reference(child common.Hash, parent common.Hash) {
 }
 
 // Dereference removes an existing reference from a root node.
+func (db *Database) DereferenceDB(root common.Hash) {
+	// Sanity check to ensure that the meta-root is not removed
+	if root == (common.Hash{}) {
+		log.Error("Attempted to dereference the trie cache meta root")
+		return
+	}
+	db.lock.Lock()
+	defer db.lock.Unlock()
+
+	nodes, storage, start := len(db.nodes), db.nodesSize, time.Now()
+	batch := db.diskdb.NewBatch()
+	clearFn := func(hash []byte) {
+		batch.Delete(hash)
+		if batch.ValueSize() > ethdb.IdealBatchSize {
+			batch.Write()
+			batch.Reset()
+		}
+	}
+	db.dereference(root, common.Hash{}, clearFn)
+
+	batch.Write()
+
+	db.gcnodes += uint64(nodes - len(db.nodes))
+	db.gcsize += storage - db.nodesSize
+	db.gctime += time.Since(start)
+
+	memcacheGCTimeTimer.Update(time.Since(start))
+	memcacheGCSizeMeter.Mark(int64(storage - db.nodesSize))
+	memcacheGCNodesMeter.Mark(int64(nodes - len(db.nodes)))
+
+	log.Debug("Dereferenced trie from memory database", "nodes", nodes-len(db.nodes), "size", storage-db.nodesSize, "time", time.Since(start),
+		"gcnodes", db.gcnodes, "gcsize", db.gcsize, "gctime", db.gctime, "livenodes", len(db.nodes), "livesize", db.nodesSize)
+}
+
+// Dereference removes an existing reference from a root node.
 func (db *Database) Dereference(root common.Hash) {
 	// Sanity check to ensure that the meta-root is not removed
 	if root == (common.Hash{}) {
@@ -447,7 +491,7 @@ func (db *Database) Dereference(root common.Hash) {
 	defer db.lock.Unlock()
 
 	nodes, storage, start := len(db.nodes), db.nodesSize, time.Now()
-	db.dereference(root, common.Hash{})
+	db.dereference(root, common.Hash{}, nil)
 
 	db.gcnodes += uint64(nodes - len(db.nodes))
 	db.gcsize += storage - db.nodesSize
@@ -462,7 +506,7 @@ func (db *Database) Dereference(root common.Hash) {
 }
 
 // dereference is the private locked version of Dereference.
-func (db *Database) dereference(child common.Hash, parent common.Hash) {
+func (db *Database) dereference(child common.Hash, parent common.Hash, clearFn func([]byte)) {
 	// Dereference the parent-child
 	node := db.nodes[parent]
 
@@ -500,11 +544,53 @@ func (db *Database) dereference(child common.Hash, parent common.Hash) {
 		}
 		// Dereference all children and delete the node
 		for _, hash := range node.childs() {
-			db.dereference(hash, child)
+			db.dereference(hash, child, clearFn)
 		}
 		delete(db.nodes, child)
+		if clearFn != nil {
+			clearFn(child.Bytes())
+		}
 		db.nodesSize -= common.StorageSize(common.HashLength + int(node.size))
 	}
+}
+
+func (db *Database) CapNode(limit common.StorageSize) {
+	db.lock.RLock()
+	nodes, storage, start := len(db.nodes), db.nodesSize, time.Now()
+	size := db.nodesSize + common.StorageSize((len(db.nodes)-1)*2*common.HashLength)
+
+	oldest := db.oldest
+	for size > limit && oldest != (common.Hash{}) {
+		// Fetch the oldest referenced node and push into the batch
+		node := db.nodes[oldest]
+		// Iterate to the next flush item, or abort if the size cap was achieved. Size
+		// is the total size, including both the useful cached data (hash -> blob), as
+		// well as the flushlist metadata (2*hash). When flushing items from the cache,
+		// we need to reduce both.
+		size -= common.StorageSize(3*common.HashLength + int(node.size))
+		oldest = node.flushNext
+	}
+	db.lock.RUnlock()
+
+	db.lock.Lock()
+	defer db.lock.Unlock()
+	for db.oldest != oldest {
+		node := db.nodes[db.oldest]
+		delete(db.nodes, db.oldest)
+		db.oldest = node.flushNext
+
+		db.nodesSize -= common.StorageSize(common.HashLength + int(node.size))
+	}
+	db.flushnodes += uint64(nodes - len(db.nodes))
+	db.flushsize += storage - db.nodesSize
+	db.flushtime += time.Since(start)
+
+	memcacheFlushTimeTimer.Update(time.Since(start))
+	memcacheFlushSizeMeter.Mark(int64(storage - db.nodesSize))
+	memcacheFlushNodesMeter.Mark(int64(nodes - len(db.nodes)))
+
+	log.Debug("Persisted nodes from memory database", "nodes", nodes-len(db.nodes), "size", storage-db.nodesSize, "time", time.Since(start),
+		"flushnodes", db.flushnodes, "flushsize", db.flushsize, "flushtime", db.flushtime, "livenodes", len(db.nodes), "livesize", db.nodesSize)
 }
 
 // Cap iteratively flushes old but still referenced trie nodes until the total
@@ -612,7 +698,7 @@ func (db *Database) Cap(limit common.StorageSize) error {
 // to disk, forcefully tearing down all references in both directions.
 //
 // As a side effect, all pre-images accumulated up to this point are also written.
-func (db *Database) Commit(node common.Hash, report bool) error {
+func (db *Database) Commit(node common.Hash, report bool, uncache bool) error {
 	// Create a database batch to flush persistent data out. It is important that
 	// outside code doesn't see an inconsistent state (referenced data removed from
 	// memory cache during commit but not yet in persistent storage). This is ensured
@@ -658,7 +744,10 @@ func (db *Database) Commit(node common.Hash, report bool) error {
 	db.preimages = make(map[common.Hash][]byte)
 	db.preimagesSize = 0
 
-	db.uncache(node)
+	if uncache {
+		db.uncache(node)
+	}
+	db.resetFreshNode()
 
 	memcacheCommitTimeTimer.Update(time.Since(start))
 	memcacheCommitSizeMeter.Mark(int64(storage - db.nodesSize))
@@ -681,10 +770,11 @@ func (db *Database) Commit(node common.Hash, report bool) error {
 // commit is the private locked version of Commit.
 func (db *Database) commit(hash common.Hash, batch ethdb.Batch) error {
 	// If the node does not exist, it's a previously committed node
-	node, ok := db.nodes[hash]
+	_, ok := db.freshNodes[hash]
 	if !ok {
 		return nil
 	}
+	node, _ := db.nodes[hash]
 	for _, child := range node.childs() {
 		if err := db.commit(child, batch); err != nil {
 			return err

--- a/trie/hasher.go
+++ b/trie/hasher.go
@@ -76,7 +76,7 @@ func returnHasherToPool(h *hasher) {
 // original node initialized with the computed hash to replace the original one.
 func (h *hasher) hash(n node, db *Database, force bool) (node, node, error) {
 	// If we're not storing the node, just hashing, use available cached data
-	if hash, dirty := n.cache(); hash != nil {
+	if hash, dirty := n.cache(); len(hash) != 0 {
 		if db == nil {
 			return hash, n, nil
 		}
@@ -106,12 +106,12 @@ func (h *hasher) hash(n node, db *Database, force bool) (node, node, error) {
 
 	switch cn := cached.(type) {
 	case *shortNode:
-		cn.flags.hash = cachedHash
+		*cn.flags.hash = cachedHash
 		if db != nil {
 			*cn.flags.dirty = false
 		}
 	case *fullNode:
-		cn.flags.hash = cachedHash
+		*cn.flags.hash = cachedHash
 		if db != nil {
 			*cn.flags.dirty = false
 		}
@@ -179,7 +179,7 @@ func (h *hasher) store(n node, db *Database, force bool) (node, error) {
 	}
 	// Larger nodes are replaced by their hash and stored in the database.
 	hash, _ := n.cache()
-	if hash == nil {
+	if len(hash) == 0 {
 		hash = h.makeHashNode(h.tmp)
 	}
 

--- a/trie/hasher.go
+++ b/trie/hasher.go
@@ -103,6 +103,7 @@ func (h *hasher) hash(n node, db *Database, force bool) (node, node, error) {
 	// the dirty flag in commit mode. It's fine to assign these values directly
 	// without copying the node first because hashChildren copies it.
 	cachedHash, _ := hashed.(hashNode)
+
 	switch cn := cached.(type) {
 	case *shortNode:
 		cn.flags.hash = cachedHash
@@ -188,6 +189,7 @@ func (h *hasher) store(n node, db *Database, force bool) (node, error) {
 
 		db.lock.Lock()
 		db.insert(hash, h.tmp, n)
+		db.insertFreshNode(hash)
 		db.lock.Unlock()
 
 		// Track external references from account->storage trie

--- a/trie/iterator_test.go
+++ b/trie/iterator_test.go
@@ -28,7 +28,7 @@ import (
 	"github.com/PlatONnetwork/PlatON-Go/ethdb"
 )
 
-func TestDecodeNode2(t *testing.T)  {
+func TestDecodeNode2(t *testing.T) {
 	val := common.Hex2Bytes("9fa1d0a5c3ba8a413015cbcc57c810d999b8046ca4ae2f0f734700a8679c615e")
 	var hash []byte
 
@@ -42,7 +42,6 @@ func TestDecodeNode2(t *testing.T)  {
 	h := common.BytesToHash(hash)
 	t.Log(h.Hex())
 }
-
 
 func TestIterator(t *testing.T) {
 	trie := newEmpty()
@@ -315,7 +314,7 @@ func testIteratorContinueAfterError(t *testing.T, memonly bool) {
 	}
 	tr.Commit(nil)
 	if !memonly {
-		triedb.Commit(tr.Hash(), true)
+		triedb.Commit(tr.Hash(), true, true)
 	}
 	wantNodeCount := checkIteratorNoDups(t, tr.NodeIterator(nil), nil)
 
@@ -402,7 +401,7 @@ func testIteratorContinueAfterSeekError(t *testing.T, memonly bool) {
 	}
 	root, _ := ctr.Commit(nil)
 	if !memonly {
-		triedb.Commit(root, true)
+		triedb.Commit(root, true, true)
 	}
 	barNodeHash := common.HexToHash("05041990364eb72fcb1127652ce40d8bab765f2bfe53225b1170d276cc101c2e")
 	var (

--- a/trie/secure_trie.go
+++ b/trie/secure_trie.go
@@ -185,7 +185,7 @@ func (t *SecureTrie) Copy() *SecureTrie {
 
 func (t *SecureTrie) New() *SecureTrie {
 	cpy := &SecureTrie{
-		trie: t.trie,
+		trie: *t.trie.DeepCopyTrie(),
 	}
 	return cpy
 }

--- a/trie/secure_trie_test.go
+++ b/trie/secure_trie_test.go
@@ -19,6 +19,7 @@ package trie
 import (
 	"bytes"
 	"fmt"
+	"github.com/PlatONnetwork/PlatON-Go/common/hexutil"
 	"github.com/stretchr/testify/assert"
 	"runtime"
 	"sync"
@@ -109,8 +110,8 @@ func TestInsertBlob(t *testing.T) {
 	root2, _ := trie2.Commit(leafcallback(triedb2, trie2))
 
 	assert.Equal(t, root1, root2)
-	triedb1.Commit(root1, true)
-	triedb2.Commit(root2, true)
+	triedb1.Commit(root1, true, true)
+	triedb2.Commit(root2, true, true)
 	for k, v := range storages {
 		valueKey1 := trie1.Get([]byte(k))
 		valueKey2 := trie2.Get([]byte(k))
@@ -129,8 +130,8 @@ func TestInsertBlob(t *testing.T) {
 	root2, _ = trie2.Commit(leafcallback(triedb2, trie2))
 
 	assert.Equal(t, root1, root2)
-	triedb1.Commit(root1, true)
-	triedb2.Commit(root2, true)
+	triedb1.Commit(root1, true, true)
+	triedb2.Commit(root2, true, true)
 	for k, v := range storages {
 		valueKey1 := trie1.Get([]byte(k))
 		valueKey2 := trie2.Get([]byte(k))
@@ -220,4 +221,11 @@ func TestSecureTrieConcurrency(t *testing.T) {
 	}
 	// Wait for all threads to finish
 	pend.Wait()
+}
+
+func TestJ(t *testing.T) {
+	_, trie, _ := makeTestSecureTrie()
+	fmt.Println(hexutil.Encode(trie.hashKey(hexutil.MustDecode("0x1000000000000000000000000000000000000004"))))
+	fmt.Println(hexutil.Encode(trie.hashKey(hexutil.MustDecode("0x1000000000000000000000000000000000000002"))))
+
 }

--- a/trie/sync.go
+++ b/trie/sync.go
@@ -228,7 +228,7 @@ func (s *Sync) Commit(dbw ethdb.Putter) (int, error) {
 		v, _ := s.membatch.batch[key]
 		if v.storage {
 			var seckeybuf [43]byte
-			buf := append(seckeybuf[:0], secureKeyPrefix...)
+			buf := append(seckeybuf[:0], SecureKeyPrefix...)
 			buf = append(buf, key[:]...)
 			if err := dbw.Put(buf, s.membatch.batch[key].data); err != nil {
 				return i, err

--- a/trie/trie.go
+++ b/trie/trie.go
@@ -87,7 +87,7 @@ func (t *Trie) SetCacheLimit(l uint16) {
 // newFlag returns the cache flag value for a newly created node.
 func (t *Trie) newFlag() nodeFlag {
 	dirty := true
-	return nodeFlag{dirty: &dirty, gen: t.cachegen}
+	return nodeFlag{hash: &hashNode{}, dirty: &dirty, gen: t.cachegen}
 }
 
 // New creates a trie with an existing root node from db.
@@ -502,12 +502,8 @@ func (t *Trie) copyNode(n node) {
 	switch n := n.(type) {
 	case *shortNode:
 		if _, ok := n.Val.(valueNode); !ok {
-			if _, dirty := n.cache(); !dirty {
-				if hash, _ := n.cache(); hash != nil {
-					empty := common.Hash{}
-					if bytes.Equal(hash, empty.Bytes()) {
-						panic("empty")
-					}
+			if _, dirty := n.Val.cache(); !dirty {
+				if hash, _ := n.Val.cache(); len(hash) != 0 {
 					n.Val = hash
 				}
 			} else {
@@ -527,11 +523,7 @@ func (t *Trie) copyNode(n node) {
 				if _, ok := n.Children[i].(valueNode); !ok {
 
 					if _, dirty := n.Children[i].cache(); !dirty {
-						if hash, _ := n.Children[i].cache(); hash != nil {
-							empty := common.Hash{}
-							if bytes.Equal(hash, empty.Bytes()) {
-								panic("empty")
-							}
+						if hash, _ := n.Children[i].cache(); len(hash) != 0 {
 							n.Children[i] = hash
 						}
 					} else {


### PR DESCRIPTION
Increase the cleanup of DB storage, mainly to clean up State history, Receipt. The default cleanup feature is turned on. Fast synchronization cancels Receipt synchronization due to cleanup of Receipt. The cleanup function provides the following parameters to adjust the cleanup action

> DB OPTIONS:
  --db.nogc               Disables database garbage collection
  --db.gc_interval value  Block interval for garbage collection (default: `86400)`
  --db.gc_timeout value   Maximum time for database garbage collection (default: 1m0s)
  --db.gc_mpt             Enables database garbage collection MPT
  --db.gc_block value     Number of cache block states, default 10 (default: 10)

Also provide an RPC interface,
> debug.disableDBGC()
 debug.enableDBGC()


Related:#714