### PR TITLE
update gov_plugin_test.go because gov.GetActiveVersion() has been rem…

### DIFF
--- a/x/plugin/gov_plugin_test.go
+++ b/x/plugin/gov_plugin_test.go
@@ -20,6 +20,8 @@ import (
 	"encoding/hex"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/PlatONnetwork/PlatON-Go/node"
 
 	"github.com/PlatONnetwork/PlatON-Go/crypto"
@@ -1256,15 +1258,11 @@ func TestGovPlugin_Test_MakeExtraData(t *testing.T) {
 			versionBytes := extraData[0].([]byte)
 			versionInHeader := common.BytesToUint32(versionBytes)
 
-			activeVersion := gov.GetActiveVersion(lastHeader.Number.Uint64(), stateDB)
+			activeVersion := gov.GetCurrentActiveVersion(stateDB)
 			t.Log("verify header version", "headerVersion", versionInHeader, "activeVersion", activeVersion, "blockNumber", lastHeader.Number.Uint64())
-			if activeVersion == versionInHeader {
-				t.Log("OK")
-			} else {
-				t.Error("header version error")
-			}
+			assert.Equal(t, activeVersion, versionInHeader)
 		} else {
-			t.Error("unknown header extra data", "elementCount", len(extraData))
+			t.Fatalf("unknown header extra data, elementCount= %d", len(extraData))
 		}
 	}
 


### PR DESCRIPTION
update gov_plugin_test.go because gov.GetActiveVersion() has been removed.