### PR TITLE
Added blsPubKey

### DIFF
--- a/cmd/platon/config.go
+++ b/cmd/platon/config.go
@@ -146,6 +146,7 @@ func makeConfigNode(ctx *cli.Context) (*node.Node, gethConfig) {
 
 	// Apply flags.
 	utils.SetNodeConfig(ctx, &cfg.Node)
+	utils.SetCbft(ctx, &cfg.Eth.CbftConfig, &cfg.Node)
 	stack, err := node.New(&cfg.Node)
 	if err != nil {
 		utils.Fatalf("Failed to create the protocol stack: %v", err)
@@ -163,7 +164,6 @@ func makeConfigNode(ctx *cli.Context) (*node.Node, gethConfig) {
 	//if cbftConfig := cfg.Eth.LoadCbftConfig(cfg.Node); cbftConfig != nil {
 	//	cfg.Eth.CbftConfig = *cbftConfig
 	//}
-	utils.SetCbft(ctx, &cfg.Eth.CbftConfig, &cfg.Node)
 
 	if ctx.GlobalIsSet(utils.EthStatsURLFlag.Name) {
 		cfg.Ethstats.URL = ctx.GlobalString(utils.EthStatsURLFlag.Name)

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1205,7 +1205,7 @@ func SetCbft(ctx *cli.Context, cfg *types.OptionsConfig, nodeCfg *node.Config) {
 	} else {
 		cfg.BlsPriKey = nodeCfg.BlsKey()
 	}
-	nodeCfg.P2P.BlsPublicKey = cfg.BlsPriKey.GetPublicKey()
+	nodeCfg.P2P.BlsPublicKey = *(cfg.BlsPriKey.GetPublicKey())
 
 	if ctx.GlobalIsSet(CbftWalDisabledFlag.Name) {
 		cfg.WalMode = !ctx.GlobalBool(CbftWalDisabledFlag.Name)

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1205,6 +1205,7 @@ func SetCbft(ctx *cli.Context, cfg *types.OptionsConfig, nodeCfg *node.Config) {
 	} else {
 		cfg.BlsPriKey = nodeCfg.BlsKey()
 	}
+	nodeCfg.P2P.BlsPublicKey = cfg.BlsPriKey.GetPublicKey()
 
 	if ctx.GlobalIsSet(CbftWalDisabledFlag.Name) {
 		cfg.WalMode = !ctx.GlobalBool(CbftWalDisabledFlag.Name)

--- a/consensus/cbft/types/config.go
+++ b/consensus/cbft/types/config.go
@@ -25,22 +25,22 @@ import (
 )
 
 type OptionsConfig struct {
-	NodePriKey *ecdsa.PrivateKey
-	NodeID     discover.NodeID
-	BlsPriKey  *bls.SecretKey
-	WalMode    bool
+	NodePriKey *ecdsa.PrivateKey `json:"-"`
+	NodeID     discover.NodeID   `json:"nodeID"`
+	BlsPriKey  *bls.SecretKey    `json:"-"`
+	WalMode    bool              `json:"walMode"`
 
-	PeerMsgQueueSize  uint64
-	EvidenceDir       string
-	MaxPingLatency    int64 // maxPingLatency is the time in milliseconds between Ping and Pong
-	MaxQueuesLimit    int64 // The maximum value that a single node can send a message.
-	BlacklistDeadline int64 // Blacklist expiration time. unit: minute.
+	PeerMsgQueueSize  uint64 `json:"peerMsgQueueSize"`
+	EvidenceDir       string `json:"evidenceDir"`
+	MaxPingLatency    int64  `json:"maxPingLatency"`    // maxPingLatency is the time in milliseconds between Ping and Pong
+	MaxQueuesLimit    int64  `json:"maxQueuesLimit"`    // The maximum value that a single node can send a message.
+	BlacklistDeadline int64  `json:"blacklistDeadline"` // Blacklist expiration time. unit: minute.
 
-	Period uint64
-	Amount uint32
+	Period uint64 `json:"period"`
+	Amount uint32 `json:"amount"`
 }
 
 type Config struct {
-	Sys    *params.CbftConfig
-	Option *OptionsConfig
+	Sys    *params.CbftConfig `json:"sys"`
+	Option *OptionsConfig     `json:"option"`
 }

--- a/p2p/server.go
+++ b/p2p/server.go
@@ -65,7 +65,7 @@ type Config struct {
 	PrivateKey *ecdsa.PrivateKey `toml:"-"`
 
 	// BlsPublicKey is a BLS public key.
-	BlsPublicKey *bls.PublicKey `toml:"-"`
+	BlsPublicKey bls.PublicKey `toml:"-"`
 
 	// chainId identifies the current chain and is used for replay protection
 	ChainID *big.Int `toml:"-"`


### PR DESCRIPTION
1. Added `blsPubKey` for `admin.nodeInfo`
```
> admin.nodeInfo
{
  blsPubKey: "97623489d3b0b29df7106fbf55272f5157e4df31cefd9674d58c02dc2ed392ac8b82c8768bcfede192d4e6ffd699f106412fa6f1d4e31415577e5d0ee72d45cb35644b17ae8bc51b69a227c880af20a9137093d46a9ab6a6e1094224a7c21688",
  enode: "enode://e37c81d3e2e582649069174578f2ce929efdd6b0c27225a00374af9877dd521834b3f5bf6ec443847ae70d403c9264e649dd5e9f2328fc0496304e955f18548b@[::]:18001",
  id: "e37c81d3e2e582649069174578f2ce929efdd6b0c27225a00374af9877dd521834b3f5bf6ec443847ae70d403c9264e649dd5e9f2328fc0496304e955f18548b",
  ip: "::",
  listenAddr: "[::]:18001",
  name: "PlatONnetwork/platon/v0.7.4-unstable-a138df50/linux-amd64/go1.12.5",
  ports: {
    discovery: 18001,
    listener: 18001
  },
  protocols: {
    cbft: {
      config: {
        option: {...},
        sys: {...}
      }
    },
    platon: {
      config: {
        cbft: {...},
        chainId: 101,
        eip155Block: 0,
        emptyBlock: "on"
      },
      genesis: "0xa81bdb696bd913aa0b47b10db3ea4517cee7ecb582b4a55d2f4a823dcc774b61",
      head: "0x4ae6890b06764bc7ba82eb4d9627d7ac184f0978ef1a684dbf521d470bf83764",
      network: 1
    }
  }
}
```
2. consensus/cbft/types/config.go: Take the same format for json