### PR TITLE
returns error message if running platon precompiled contract failed.

### DIFF
--- a/core/vm/platon_contract_tool.go
+++ b/core/vm/platon_contract_tool.go
@@ -16,13 +16,13 @@ func execPlatonContract(input []byte, command map[uint16]interface{}) (ret []byt
 	_, fn, params, err := plugin.VerifyTxData(input, command)
 	if nil != err {
 		log.Error("Failed to verify contract tx before exec", "err", err)
-		return nil, err
+		return xcom.NewFailedResult(common.InvalidParameter), err
 	}
 
 	// execute contracts method
 	result := reflect.ValueOf(fn).Call(params)
 	if err, ok := result[1].Interface().(error); ok {
-		return nil, err
+		return xcom.NewFailedResult(common.InternalError), err
 	}
 	return result[0].Bytes(), nil
 }


### PR DESCRIPTION
RPC will return the proper error message if client requests a RPC with wrong arguments.