### PR TITLE
add check err in gov_params.go

### DIFF
--- a/x/gov/gov_params.go
+++ b/x/gov/gov_params.go
@@ -121,8 +121,10 @@ func initParam() []*GovernParam {
 					return fmt.Errorf("Parsed UnStakeFreezeDuration is failed: %v", err)
 				}
 
-				age, _ := GovernMaxEvidenceAge(blockNumber, blockHash)
-
+				age, err := GovernMaxEvidenceAge(blockNumber, blockHash)
+				if nil != err {
+					return err
+				}
 				if err := xcom.CheckUnStakeFreezeDuration(num, int(age)); nil != err {
 					return err
 				}
@@ -185,8 +187,10 @@ func initParam() []*GovernParam {
 					return fmt.Errorf("Parsed MaxEvidenceAge is failed: %v", err)
 				}
 
-				duration, _ := GovernUnStakeFreezeDuration(blockNumber, blockHash)
-
+				duration, err := GovernUnStakeFreezeDuration(blockNumber, blockHash)
+				if nil != err {
+					return err
+				}
 				if err := xcom.CheckMaxEvidenceAge(age, int(duration)); nil != err {
 					return err
 				}


### PR DESCRIPTION
add check `err` in gov_params.go for `GovernMaxEvidenceAge` and `GovernUnStakeFreezeDuration`

Signed-off-by: gavin <meiyan532484710@163.com>