### PR TITLE
TrieDB cache enhance

### DIFF
--- a/cmd/platon/main.go
+++ b/cmd/platon/main.go
@@ -83,6 +83,7 @@ var (
 		utils.CacheFlag,
 		utils.CacheDatabaseFlag,
 		utils.CacheGCFlag,
+		utils.CacheTrieDBFlag,
 		utils.TrieCacheGenFlag,
 		utils.ListenPortFlag,
 		utils.MaxPeersFlag,

--- a/cmd/platon/usage.go
+++ b/cmd/platon/usage.go
@@ -121,6 +121,7 @@ var AppHelpFlagGroups = []flagGroup{
 			utils.CacheFlag,
 			utils.CacheDatabaseFlag,
 			utils.CacheGCFlag,
+			utils.CacheTrieDBFlag,
 			utils.TrieCacheGenFlag,
 		},
 	},

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -248,6 +248,11 @@ var (
 		Usage: "Percentage of cache memory allowance to use for trie pruning",
 		Value: 25,
 	}
+	CacheTrieDBFlag = cli.IntFlag{
+		Name:  "cache.triedb",
+		Usage: "Megabytes of memory allocated to triedb internal caching",
+		Value: eth.DefaultConfig.TrieDBCache,
+	}
 	TrieCacheGenFlag = cli.IntFlag{
 		Name:  "trie-cache-gens",
 		Usage: "Number of trie node generations to keep in memory",
@@ -591,7 +596,7 @@ var (
 		Name:  "db.gc_mpt",
 		Usage: "Enables database garbage collection MPT",
 	}
-	DBGCBlockFlag = cli.Uint64Flag{
+	DBGCBlockFlag = cli.IntFlag{
 		Name:  "db.gc_block",
 		Usage: "Number of cache block states, default 10",
 		Value: eth.DefaultConfig.DBGCBlock,
@@ -1126,6 +1131,9 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *eth.Config) {
 	if ctx.GlobalIsSet(CacheFlag.Name) || ctx.GlobalIsSet(CacheGCFlag.Name) {
 		cfg.TrieCache = ctx.GlobalInt(CacheFlag.Name) * ctx.GlobalInt(CacheGCFlag.Name) / 100
 	}
+	if ctx.GlobalIsSet(CacheTrieDBFlag.Name) {
+		cfg.TrieDBCache = ctx.GlobalInt(CacheTrieDBFlag.Name)
+	}
 	if ctx.GlobalIsSet(DocRootFlag.Name) {
 		cfg.DocRoot = ctx.GlobalString(DocRootFlag.Name)
 	}
@@ -1181,7 +1189,7 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *eth.Config) {
 		cfg.DBGCMpt = ctx.GlobalBool(DBGCMptFlag.Name)
 	}
 	if ctx.GlobalIsSet(DBGCBlockFlag.Name) {
-		b := ctx.GlobalUint64(DBGCBlockFlag.Name)
+		b := ctx.GlobalInt(DBGCBlockFlag.Name)
 		if b > 0 {
 			cfg.DBGCBlock = b
 		}

--- a/core/state/database.go
+++ b/core/state/database.go
@@ -87,6 +87,15 @@ func NewDatabase(db ethdb.Database) Database {
 	}
 }
 
+func NewDatabaseWithCache(db ethdb.Database, cache int) Database {
+	//LRU
+	csc, _ := lru.New(codeSizeCacheSize)
+	return &cachingDB{
+		db:            trie.NewDatabaseWithCache(db, cache),
+		codeSizeCache: csc,
+	}
+}
+
 type cachingDB struct {
 	db            *trie.Database
 	mu            sync.Mutex

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -173,7 +173,8 @@ func New(ctx *node.ServiceContext, config *Config) (*Ethereum, error) {
 		cacheConfig = &core.CacheConfig{Disabled: config.NoPruning, TrieNodeLimit: config.TrieCache, TrieTimeLimit: config.TrieTimeout,
 			BodyCacheLimit: config.BodyCacheLimit, BlockCacheLimit: config.BlockCacheLimit,
 			MaxFutureBlocks: config.MaxFutureBlocks, BadBlockLimit: config.BadBlockLimit,
-			TriesInMemory: config.TriesInMemory, DBGCInterval: config.DBGCInterval, DBGCTimeout: config.DBGCTimeout,
+			TriesInMemory: config.TriesInMemory, TrieDBCache: config.TrieDBCache,
+			DBGCInterval: config.DBGCInterval, DBGCTimeout: config.DBGCTimeout,
 			DBGCMpt: config.DBGCMpt, DBGCBlock: config.DBGCBlock,
 		}
 

--- a/eth/config.go
+++ b/eth/config.go
@@ -49,8 +49,9 @@ var DefaultConfig = Config{
 	NetworkId:     1,
 	LightPeers:    100,
 	DatabaseCache: 768,
-	TrieCache:     128,
+	TrieCache:     32,
 	TrieTimeout:   60 * time.Minute,
+	TrieDBCache:   512,
 	MinerGasFloor: params.GenesisGasLimit,
 	//MinerGasCeil:  4000 * 21000 * 1.2,
 	DBDisabledGC:  false,
@@ -115,11 +116,12 @@ type Config struct {
 	DatabaseCache      int
 	TrieCache          int
 	TrieTimeout        time.Duration
+	TrieDBCache        int
 	DBDisabledGC       bool
 	DBGCInterval       uint64
 	DBGCTimeout        time.Duration
 	DBGCMpt            bool
-	DBGCBlock          uint64
+	DBGCBlock          int
 
 	// Mining-related options
 	MinerExtraData []byte `toml:",omitempty"`

--- a/trie/bigcache.go
+++ b/trie/bigcache.go
@@ -1,0 +1,300 @@
+package trie
+
+import (
+	"container/list"
+	"errors"
+	"sync"
+	"sync/atomic"
+)
+
+const (
+	// offset64 FNVa offset basis. See https://en.wikipedia.org/wiki/Fowler–Noll–Vo_hash_function#FNV-1a_hash
+	offset64 = 14695981039346656037
+	// prime64 FNVa prime value. See https://en.wikipedia.org/wiki/Fowler–Noll–Vo_hash_function#FNV-1a_hash
+	prime64 = 1099511628211
+
+	// maxValueSize The maximum size for entry value.
+	maxValueSize = 1024
+)
+
+// Sum64 gets the string and returns its uint64 hash value.
+func Sum64(key string) uint64 {
+	var hash uint64 = offset64
+	for i := 0; i < len(key); i++ {
+		hash ^= uint64(key[i])
+		hash *= prime64
+	}
+
+	return hash
+}
+
+// LRU implements a non-thread safe fixed size LRU cache
+type LRU struct {
+	capacity    uint64
+	maxCapacity uint64
+	evictList   *list.List
+	items       map[string]*list.Element
+}
+
+// entry is used to hold a value in the evictList
+type entry struct {
+	key   string
+	value []byte
+}
+
+// NewLRU constructs an LRU of the given size
+func NewLRU(size uint64) (*LRU, error) {
+	if size <= 0 {
+		return nil, errors.New("Must provide a positive size")
+	}
+	c := &LRU{
+		capacity:    0,
+		maxCapacity: size,
+		evictList:   list.New(),
+		items:       make(map[string]*list.Element),
+	}
+	return c, nil
+}
+
+// Add adds a value to the cache.  Returns true if an eviction occurred.
+func (c *LRU) Add(key string, value []byte) bool {
+	// Check for existing item
+	if ent, ok := c.items[key]; ok {
+		c.evictList.MoveToFront(ent)
+		c.capacity -= uint64(len(ent.Value.(*entry).value))
+		ent.Value.(*entry).value = value
+		c.capacity += uint64(len(value))
+		return false
+	}
+
+	// Add new item
+	ent := &entry{key, value}
+	entry := c.evictList.PushFront(ent)
+	c.items[key] = entry
+	c.capacity += uint64(len(value))
+	c.capacity += uint64(len(key))
+
+	evict := c.capacity > c.maxCapacity
+	// Verify size not exceeded
+	if evict {
+		c.removeOldest()
+	}
+	return evict
+}
+
+// Get looks up a key's value from the cache.
+func (c *LRU) Get(key string) (value []byte, ok bool) {
+	if ent, ok := c.items[key]; ok {
+		c.evictList.MoveToFront(ent)
+		return ent.Value.(*entry).value, true
+	}
+	return
+}
+
+// Remove removes the provided key from the cache, returning if the
+// key was contained.
+func (c *LRU) Remove(key string) bool {
+	if ent, ok := c.items[key]; ok {
+		c.removeElement(ent)
+		return true
+	}
+	return false
+}
+
+// Len returns the number of items in the cache.
+func (c *LRU) Len() int {
+	return c.evictList.Len()
+}
+
+func (c *LRU) Capacity() uint64 {
+	return c.capacity
+}
+
+// removeOldest removes the oldest item from the cache.
+func (c *LRU) removeOldest() {
+	for c.capacity > c.maxCapacity {
+		ent := c.evictList.Back()
+		if ent != nil {
+			c.removeElement(ent)
+		}
+	}
+}
+
+// removeElement is used to remove a given list element from the cache
+func (c *LRU) removeElement(e *list.Element) {
+	c.evictList.Remove(e)
+	kv := e.Value.(*entry)
+	delete(c.items, kv.key)
+	c.capacity -= uint64(len(kv.value))
+	c.capacity -= uint64(len(kv.key))
+}
+
+type Stats struct {
+	Hits      int64 // Hits is a number of successfully found keys
+	Misses    int64 // Misses is a number of not found keys
+	DelHits   int64 // DelHits is a number of successfully deleted keys
+	DelMisses int64 // DelMisses is a number of not deleted keys
+}
+
+type BigCache struct {
+	shards    []*shard
+	shardMask uint64
+	lock      sync.RWMutex
+	lru       *LRU
+
+	hits int64
+}
+
+type shard struct {
+	entries *LRU
+	lock    sync.RWMutex
+	stats   Stats
+}
+
+func NewBigCache(capacity uint64, size int) *BigCache {
+	shards := make([]*shard, size)
+	shardCap := (7 * capacity / 8) / uint64(size)
+	for i := 0; i < size; i++ {
+		shards[i] = newShard(shardCap)
+	}
+	lru, _ := NewLRU(capacity / 8)
+
+	return &BigCache{
+		shards:    shards,
+		shardMask: uint64(size) - 1,
+		lru:       lru,
+	}
+}
+
+func (c *BigCache) Set(key string, value []byte) {
+	if len(value) > maxValueSize {
+		return
+	}
+
+	hash := Sum64(key)
+	shard := c.getShard(hash)
+	shard.set(key, value)
+}
+
+func (c *BigCache) SetLru(key string, value []byte) {
+	if len(value) > maxValueSize {
+		return
+	}
+
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	c.lru.Add(key, value)
+}
+
+func (c *BigCache) Get(key string) ([]byte, bool) {
+	c.lock.RLock()
+	if val, ok := c.lru.Get(key); ok {
+		atomic.AddInt64(&c.hits, 1)
+		c.lock.RUnlock()
+		return val, true
+	}
+	c.lock.RUnlock()
+
+	hash := Sum64(key)
+	shard := c.getShard(hash)
+	return shard.get(key)
+}
+
+func (c *BigCache) Delele(key string) {
+	hash := Sum64(key)
+	shard := c.getShard(hash)
+	shard.delete(key)
+}
+
+func (c *BigCache) Len() uint64 {
+	len := c.lru.Len()
+	for _, shard := range c.shards {
+		len += shard.entries.Len()
+	}
+	return uint64(len)
+}
+
+func (c *BigCache) Capacity() uint64 {
+	var cap uint64 = 0
+	c.lock.RLock()
+	cap = c.lru.Capacity()
+	c.lock.RUnlock()
+
+	for _, shard := range c.shards {
+		cap += shard.entries.Capacity()
+	}
+	return cap
+}
+
+func (c *BigCache) Stats() Stats {
+	var stats Stats
+	stats.Hits = atomic.LoadInt64(&c.hits)
+	for _, shard := range c.shards {
+		s := shard.Stats()
+		stats.Hits += s.Hits
+		stats.Misses += s.Misses
+		stats.DelHits += s.DelHits
+		stats.DelMisses += s.DelMisses
+	}
+	return stats
+}
+
+func (c *BigCache) ResetStats() {
+	c.lock.Lock()
+	c.hits = 0
+	c.lock.Unlock()
+
+	for _, shard := range c.shards {
+		shard.resetStats()
+	}
+}
+
+func (c *BigCache) getShard(hash uint64) *shard {
+	return c.shards[c.shardMask&hash]
+}
+
+func newShard(capacity uint64) *shard {
+	entries, _ := NewLRU(capacity)
+	return &shard{
+		entries: entries,
+	}
+}
+
+func (s *shard) set(key string, value []byte) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	s.entries.Add(key, value)
+}
+
+func (s *shard) get(key string) ([]byte, bool) {
+	s.lock.RLock()
+	defer s.lock.RUnlock()
+	if val, ok := s.entries.Get(key); ok {
+		s.stats.Hits++
+		return val, ok
+	}
+	s.stats.Misses++
+	return nil, false
+}
+
+func (s *shard) delete(key string) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	if s.entries.Remove(key) {
+		s.stats.DelHits++
+		return
+	}
+	s.stats.DelMisses++
+}
+
+func (s *shard) Stats() Stats {
+	s.lock.RLock()
+	defer s.lock.RUnlock()
+	return s.stats
+}
+
+func (s *shard) resetStats() {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	s.stats = Stats{}
+}

--- a/trie/bigcache_test.go
+++ b/trie/bigcache_test.go
@@ -1,0 +1,73 @@
+package trie
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestBigCache(t *testing.T) {
+	bc := NewBigCache(1000000, 6)
+	assert.NotNil(t, bc)
+
+	assert.True(t, bc.getShard(0) == bc.shards[0])
+	assert.True(t, bc.getShard(5) == bc.shards[5])
+
+	bc.Set("test", []byte("111111"))
+	v, ok := bc.Get("test")
+	assert.Equal(t, v, []byte("111111"))
+	assert.True(t, ok)
+
+	assert.True(t, bc.Len() == 1)
+	assert.True(t, bc.Capacity() == 10)
+
+	stats := bc.Stats()
+	assert.True(t, stats.Hits == 1)
+	assert.True(t, stats.Misses == 0)
+
+	bc.Delele("test")
+	_, ok = bc.Get("test")
+	assert.False(t, ok)
+
+	stats = bc.Stats()
+	assert.True(t, stats.DelHits == 1)
+	assert.True(t, stats.Misses == 1)
+
+	bc.SetLru("test", []byte("111111"))
+	v, ok = bc.Get("test")
+	assert.True(t, ok)
+	assert.Equal(t, v, []byte("111111"))
+
+	_, ok = bc.Get("11")
+	assert.False(t, ok)
+
+	val := make([]byte, 1024)
+	bc.Set("key1024", val)
+	v, ok = bc.Get("key1024")
+	assert.True(t, ok)
+	assert.Equal(t, v, val)
+
+	val = make([]byte, 1025)
+	bc.Set("key1025", val)
+	_, ok = bc.Get("key1025")
+	assert.False(t, ok)
+
+	bc.SetLru("lru1025", val)
+	_, ok = bc.Get("lru1025")
+	assert.False(t, ok)
+
+	bc.SetLru("test", []byte("123"))
+	v, _ = bc.Get("test")
+	assert.Equal(t, v, []byte("123"))
+
+	bc = NewBigCache(20, 1)
+
+	bc.Set("test", []byte("111111"))
+	v, _ = bc.Get("test")
+	assert.Equal(t, v, []byte("111111"))
+	bc.Set("test1", []byte("123"))
+	_, ok = bc.Get("test")
+	assert.False(t, ok)
+	_, ok = bc.Get("test1")
+	assert.True(t, ok)
+
+}


### PR DESCRIPTION
After the PR  #740 merged, through several tests, we found that: 
- TrieDB's origin cached nodes, hits rate too low
- And waste too many memory
- Has many KVs get from disk
- Have serious performance issues when MPT increase bigger

So, we added a cache between TrieDB and LevelDB to solve the above issues.

For this PR, have below changes:
- Add an option for performance
> PERFORMANCE TUNING OPTIONS:                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        
>   --cache.triedb value     Megabytes of memory allocated to triedb internal caching (default: 512)  
- Add a new type `BigCache` to cache `nodes`
- Decrease default `TrieCache` to save memory
- Lazy delete useless `nodes`