### PR TITLE
Feature/bump version to 0.7.5

### DIFF
--- a/core/vm/staking_contract.go
+++ b/core/vm/staking_contract.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 	"math/big"
 
+	"github.com/PlatONnetwork/PlatON-Go/x/xcom"
+
 	"github.com/PlatONnetwork/PlatON-Go/common/hexutil"
 
 	"github.com/PlatONnetwork/PlatON-Go/node"
@@ -849,9 +851,9 @@ func (stkc *StakingContract) getStakingReward() ([]byte, error) {
 }
 
 func (stkc *StakingContract) getAvgPackTime() ([]byte, error) {
-	avgPackTime, err := plugin.LoadAvgPackTime(common.ZeroHash, snapshotdb.Instance())
+	avgPackTime, err := xcom.LoadCurrentAvgPackTime()
 	if nil != err {
-		return callResultHandler(stkc.Evm, "getAvgPackTime", nil, common.NotFound.Wrap(err.Error())), nil
+		return callResultHandler(stkc.Evm, "getAvgPackTime", nil, common.InternalError.Wrap(err.Error())), nil
 	}
 	return callResultHandler(stkc.Evm, "getAvgPackTime", avgPackTime, nil), nil
 }

--- a/x/plugin/reward_plugin.go
+++ b/x/plugin/reward_plugin.go
@@ -317,7 +317,7 @@ func (rmp *RewardMgrPlugin) CalcEpochReward(blockHash common.Hash, head *types.H
 			"currBlockTime", head.Time.Int64(), "yearStartBlockNumber", yearStartBlockNumber, "yearStartTime", yearStartTime, "diffNumber", diffNumber, "diffTime", diffTime,
 			"avgPackTime", avgPackTime)
 	}
-	if err := StorageAvgPackTime(blockHash, rmp.db, avgPackTime); nil != err {
+	if err := xcom.StorageAvgPackTime(blockHash, rmp.db, avgPackTime); nil != err {
 		log.Error("Failed to execute StorageAvgPackTime function", "currentBlockNumber", head.Number, "currentBlockHash", blockHash.TerminalString(), "avgPackTime", avgPackTime, "err", err)
 		return nil, nil, err
 	}
@@ -571,24 +571,4 @@ func IsYearEnd(hash common.Hash, blockNumber uint64, db snapshotdb.DB) (bool, er
 		return true, nil
 	}
 	return false, nil
-}
-
-func StorageAvgPackTime(hash common.Hash, snapshotDB snapshotdb.DB, avgPackTime uint64) error {
-	if err := snapshotDB.Put(hash, reward.AvgPackTimeKey, common.Uint64ToBytes(avgPackTime)); nil != err {
-		log.Error("Failed to execute StorageAvgPackTime function", "hash", hash.TerminalString(), "avgPackTime", avgPackTime, "err", err)
-		return err
-	}
-	return nil
-}
-
-func LoadAvgPackTime(hash common.Hash, snapshotDB snapshotdb.DB) (uint64, error) {
-	avgPackTimeByte, err := snapshotDB.Get(hash, reward.AvgPackTimeKey)
-	if nil != err {
-		if err == snapshotdb.ErrNotFound {
-			return 0, nil
-		}
-		log.Error("Failed to execute LoadAvgPackTime function", "hash", hash.TerminalString(), "key", string(reward.AvgPackTimeKey), "err", err)
-		return 0, err
-	}
-	return common.BytesToUint64(avgPackTimeByte), nil
 }

--- a/x/reward/reward_db_key.go
+++ b/x/reward/reward_db_key.go
@@ -31,7 +31,6 @@ var (
 	NewBlockRewardKey        = []byte("NewBlockRewardKey")
 	StakingRewardKey         = []byte("StakingRewardKey")
 	ChainYearNumberKey       = []byte("ChainYearNumberKey")
-	AvgPackTimeKey           = []byte("AvgPackTimeKey")
 )
 
 // GetHistoryIncreaseKey used for search the balance of reward pool at last year

--- a/x/xcom/common.go
+++ b/x/xcom/common.go
@@ -1,0 +1,35 @@
+package xcom
+
+import (
+	"github.com/PlatONnetwork/PlatON-Go/common"
+	"github.com/PlatONnetwork/PlatON-Go/core/snapshotdb"
+	"github.com/PlatONnetwork/PlatON-Go/log"
+)
+
+// saves block average pack time (millisecond) to snapshot db.
+func StorageAvgPackTime(hash common.Hash, snapshotDB snapshotdb.DB, avgPackTime uint64) error {
+	if err := snapshotDB.Put(hash, AvgPackTimeKey, common.Uint64ToBytes(avgPackTime)); nil != err {
+		log.Error("Failed to save block average pack time", "hash", hash.TerminalString(), "avgPackTime", avgPackTime, "err", err)
+		return err
+	}
+	return nil
+}
+
+// gets block average pack time (millisecond) from snapshot db.
+func LoadCurrentAvgPackTime() (uint64, error) {
+	return LoadAvgPackTime(common.ZeroHash, snapshotdb.Instance())
+}
+
+// gets block average pack time (millisecond) from snapshot db.
+func LoadAvgPackTime(hash common.Hash, snapshotDB snapshotdb.DB) (uint64, error) {
+	avgPackTimeByte, err := snapshotDB.Get(hash, AvgPackTimeKey)
+
+	if nil != err {
+		if err == snapshotdb.ErrNotFound {
+			return 0, nil
+		}
+		log.Error("Failed to load block average pack time", "hash", hash.TerminalString(), "key", string(AvgPackTimeKey), "err", err)
+		return 0, err
+	}
+	return common.BytesToUint64(avgPackTimeByte), nil
+}

--- a/x/xcom/common_config.go
+++ b/x/xcom/common_config.go
@@ -43,7 +43,7 @@ const (
 	Eighty                    = 80
 	Hundred                   = 100
 	TenThousand               = 10000
-	CeilBlocksReward          = 60101
+	CeilBlocksReward          = 50000
 	CeilMaxValidators         = 201
 	FloorMaxConsensusVals     = 4
 	CeilMaxConsensusVals      = 25

--- a/x/xcom/common_keys.go
+++ b/x/xcom/common_keys.go
@@ -1,0 +1,5 @@
+package xcom
+
+var (
+	AvgPackTimeKey = []byte("AvgPackTimeKey")
+)

--- a/x/xcom/common_test.go
+++ b/x/xcom/common_test.go
@@ -1,0 +1,80 @@
+package xcom
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/PlatONnetwork/PlatON-Go/core/snapshotdb"
+
+	"github.com/PlatONnetwork/PlatON-Go/common"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/PlatONnetwork/PlatON-Go/common/mock"
+)
+
+func setup(t *testing.T) *mock.Chain {
+	t.Log("setup()......")
+	chain := mock.NewChain()
+	chain.AddBlock()
+	err := chain.SnapDB.NewBlock(chain.CurrentHeader().Number, chain.CurrentHeader().ParentHash, chain.CurrentHeader().Hash())
+	if err != nil {
+		fmt.Println("newBlock, %", err)
+	}
+	StorageAvgPackTime(chain.CurrentHeader().Hash(), chain.SnapDB, uint64(2000))
+	commit_sndb(chain)
+
+	prepair_sndb(chain, chain.CurrentHeader().Hash())
+	return chain
+}
+
+func clear(chain *mock.Chain, t *testing.T) {
+	t.Log("tear down()......")
+	if err := chain.SnapDB.Clear(); err != nil {
+		t.Error("clear chain.SnapDB error", err)
+	}
+}
+
+func commit_sndb(chain *mock.Chain) {
+	/*
+		//Flush() signs a Hash to the current block which has no hash yet. Flush() do not write the data to database.
+		//in this file, all blocks in each test case has a hash already, so, do not call Flush()
+				if err := chain.SnapDB.Flush(chain.CurrentHeader().Hash(), chain.CurrentHeader().Number); err != nil {
+					fmt.Println("commit_sndb error:", err)
+				}
+	*/
+	if err := chain.SnapDB.Commit(chain.CurrentHeader().Hash()); err != nil {
+		fmt.Println("commit_sndb error:", err)
+	}
+}
+
+func prepair_sndb(chain *mock.Chain, txHash common.Hash) {
+	if txHash == common.ZeroHash {
+		chain.AddBlock()
+	} else {
+		chain.AddBlockWithTxHash(txHash)
+	}
+	if err := chain.SnapDB.NewBlock(chain.CurrentHeader().Number, chain.CurrentHeader().ParentHash, chain.CurrentHeader().Hash()); err != nil {
+		fmt.Println("prepair_sndb error:", err)
+	}
+}
+
+func TestCommon_StorageAvgPackTime(t *testing.T) {
+	chain := setup(t)
+	defer clear(chain, t)
+
+	avgPackTime, err := LoadCurrentAvgPackTime()
+	if err != nil {
+		t.Error("load current block average pack time error", err)
+	}
+
+	assert.Equal(t, uint64(2000), avgPackTime)
+	StorageAvgPackTime(chain.CurrentHeader().Hash(), snapshotdb.Instance(), uint64(3000))
+	//commit_sndb(chain)
+
+	avgPackTime, err = LoadAvgPackTime(chain.CurrentHeader().Hash(), snapshotdb.Instance())
+	assert.Equal(t, uint64(3000), avgPackTime)
+
+	avgPackTime, err = LoadCurrentAvgPackTime()
+	assert.Equal(t, uint64(2000), avgPackTime)
+}

--- a/x/xutil/calculate.go
+++ b/x/xutil/calculate.go
@@ -96,7 +96,8 @@ func CalcEpochDuration() uint64 {
 }
 
 func CalcConsensusRounds(seconds uint64) uint64 {
-	return seconds / (xcom.Interval() * ConsensusSize())
+	//v0.7.5, hard code 1 second per block.
+	return seconds / (1 * ConsensusSize())
 }
 
 func CalcEpochRounds(seconds uint64) uint64 {


### PR DESCRIPTION
1. hard code 1 second per block when counting consensus rounds.
2. refactor code, move the code which saves/loads bock average pack time to separate files.
