### PR TITLE
Increase the inspection of the first issuance

### DIFF
--- a/x/plugin/reward_plugin_test.go
+++ b/x/plugin/reward_plugin_test.go
@@ -122,6 +122,9 @@ func buildTestStakingData(epochStart, epochEnd uint64) (staking.ValidatorQueue, 
 }
 
 func TestRewardPlugin_CalcEpochReward(t *testing.T) {
+	defer func() {
+		snapshotdb.Instance().Clear()
+	}()
 	chain := mock.NewChain()
 	chain.SetHeaderTimeGenerate(func(b *big.Int) *big.Int {
 		tmp := new(big.Int).Set(b)


### PR DESCRIPTION
#883

After the increase issuance logic is extracted as a function, the sampling range for calculating the average block time is reduced by one settlement cycle.