### PR TITLE
fix ut error on go1.13.5

### DIFF
--- a/crypto/ecies/ecies_test.go
+++ b/crypto/ecies/ecies_test.go
@@ -35,21 +35,12 @@ import (
 	"crypto/rand"
 	"crypto/sha256"
 	"encoding/hex"
-	"flag"
 	"fmt"
 	"math/big"
 	"testing"
 
 	"github.com/PlatONnetwork/PlatON-Go/crypto"
 )
-
-var dumpEnc bool
-
-func init() {
-	flDump := flag.Bool("dump", false, "write encrypted test message to file")
-	flag.Parse()
-	dumpEnc = *flDump
-}
 
 // Ensure the KDF generates appropriately sized keys.
 func TestKDF(t *testing.T) {


### PR DESCRIPTION
fixed following error on go 1.13.5 or later
`
flag provided but not defined: -test.timeout
Usage of /tmp/go-build928735462/b001/ecies.test:
  -dump
        write encrypted test message to file
FAIL    github.com/PlatONnetwork/PlatON-Go/crypto/ecies 0.019s
FAIL
`