### PR TITLE
fixed external function `Migrate` AND Use gas default value to some external functions

### DIFF
--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -230,7 +230,7 @@ func (st *StateTransition) TransitionDb() (ret []byte, usedGas uint64, failed bo
 		ret, st.gas, vmerr = evm.Call(sender, st.to(), st.data, st.gas, st.value)
 	}
 	if vmerr != nil {
-		log.Error("VM returned with error", "err", vmerr)
+		log.Error("VM returned with error", "blockNumber", evm.BlockNumber, "txHash", evm.StateDB.TxHash().TerminalString(), "err", vmerr)
 		// A possible consensus-error would be if there wasn't
 		// sufficient balance to make the transfer happen. The first
 		// balance transfer may never fail.


### PR DESCRIPTION
1、fixed external function `Migrate`
2、In external functions such as `CallContract`,` DelegateCall`, `Migrate`, if the value of the passed cost is` 0`, the value of `ctx.contract.Gas` needs to be used as the value of cost.