### PR TITLE
Partial refunds for deleted data stored in wasm

### DIFF
--- a/core/vm/wagon_runtime.go
+++ b/core/vm/wagon_runtime.go
@@ -931,18 +931,10 @@ func Transfer(proc *exec.Process, dst uint32, amount uint32, len uint32) int32 {
 }
 
 // storage external function
-
 func SetState(proc *exec.Process, key uint32, keyLen uint32, val uint32, valLen uint32) {
 	ctx := proc.HostCtx().(*VMContext)
 	if ctx.readOnly {
 		panic(ErrWASMWriteProtection)
-	}
-
-	switch {
-	case valLen == 0:
-		checkGas(ctx, params.SstoreClearGas)
-	default:
-		checkGas(ctx, (toWordSize(uint64(keyLen)+(uint64(valLen)))/32)*params.SstoreSetGas)
 	}
 
 	keyBuf := make([]byte, keyLen)
@@ -950,6 +942,42 @@ func SetState(proc *exec.Process, key uint32, keyLen uint32, val uint32, valLen 
 	if nil != err {
 		panic(err)
 	}
+
+	currentValue := ctx.evm.StateDB.GetState(ctx.contract.Address(), keyBuf)
+	oldWordSize := toWordSize(uint64(keyLen) + uint64(len(currentValue)))
+	newWordSize := toWordSize(uint64(keyLen) + uint64(valLen))
+
+	switch {
+	case 0 == len(currentValue) && 0 != valLen:
+		checkGas(ctx, newWordSize*params.SstoreSetGas)
+	case 0 != len(currentValue) && 0 == valLen:
+		ctx.evm.StateDB.AddRefund(oldWordSize * params.SstoreRefundGas)
+		checkGas(ctx, oldWordSize*params.SstoreClearGas)
+	default:
+		var (
+			addWordSize    uint64 = 0
+			deleteWordSize uint64 = 0
+			resetWordSize  uint64 = 0
+		)
+
+		if newWordSize >= oldWordSize {
+			addWordSize = newWordSize - oldWordSize
+			resetWordSize = toWordSize(uint64(len(currentValue)))
+		} else {
+			deleteWordSize = oldWordSize - newWordSize
+			resetWordSize = toWordSize(uint64(valLen))
+		}
+
+		if 0 == resetWordSize {
+			resetWordSize = 1
+		}
+
+		checkGas(ctx, addWordSize*params.SstoreSetGas)
+		ctx.evm.StateDB.AddRefund(deleteWordSize * params.SstoreRefundGas)
+		checkGas(ctx, deleteWordSize*params.SstoreClearGas)
+		checkGas(ctx, resetWordSize*params.SstoreResetGas)
+	}
+
 	valBuf := make([]byte, valLen)
 	_, err = proc.ReadAt(valBuf, int64(val))
 	if nil != err {


### PR DESCRIPTION
Wasm stores new data with 32 bytes for billing, deleting data requires a refund, and changing data to change the unit price

The charging standard is settled every 32 bytes, and the number of less than 32 bytes is rounded up.
1. Increasing the storage of data consumes 20000 gas per 32 bytes.
2. To delete data, a cleaning fee of 5000 gas is consumed for every 32 bytes, and 15000 gas is refunded for every 32 bytes.
3. Change the data, the new part consumes 20000 gas per 32 bytes. The reduced part consumes 5000 gas cleaning fee for every 32 bytes, and there is a 15000 gas refund. The value of the same length consumes 5000 gas change fee per 32 bytes. When the same length is 0, it is processed as 32 bytes.

issue: https://github.com/PlatONnetwork/PlatON-Go/issues/1487