### PR TITLE
Fix: convert common.Address to Bech32 when call Alaya JSON-RPC

### DIFF
--- a/ethclient/ethclient.go
+++ b/ethclient/ethclient.go
@@ -303,7 +303,8 @@ func (ec *Client) NetworkID(ctx context.Context) (*big.Int, error) {
 // The block number can be nil, in which case the balance is taken from the latest known block.
 func (ec *Client) BalanceAt(ctx context.Context, account common.Address, blockNumber *big.Int) (*big.Int, error) {
 	var result hexutil.Big
-	err := ec.c.CallContext(ctx, &result, "platon_getBalance", account, toBlockNumArg(blockNumber))
+	address := account.Bech32WithPrefix(common.GetAddressPrefix())
+	err := ec.c.CallContext(ctx, &result, "platon_getBalance", address, toBlockNumArg(blockNumber))
 	return (*big.Int)(&result), err
 }
 
@@ -311,7 +312,8 @@ func (ec *Client) BalanceAt(ctx context.Context, account common.Address, blockNu
 // The block number can be nil, in which case the value is taken from the latest known block.
 func (ec *Client) StorageAt(ctx context.Context, account common.Address, key common.Hash, blockNumber *big.Int) ([]byte, error) {
 	var result hexutil.Bytes
-	err := ec.c.CallContext(ctx, &result, "platon_getStorageAt", account, key, toBlockNumArg(blockNumber))
+	address := account.Bech32WithPrefix(common.GetAddressPrefix())
+	err := ec.c.CallContext(ctx, &result, "platon_getStorageAt", address, key, toBlockNumArg(blockNumber))
 	return result, err
 }
 
@@ -319,7 +321,8 @@ func (ec *Client) StorageAt(ctx context.Context, account common.Address, key com
 // The block number can be nil, in which case the code is taken from the latest known block.
 func (ec *Client) CodeAt(ctx context.Context, account common.Address, blockNumber *big.Int) ([]byte, error) {
 	var result hexutil.Bytes
-	err := ec.c.CallContext(ctx, &result, "platon_getCode", account, toBlockNumArg(blockNumber))
+	address := account.Bech32WithPrefix(common.GetAddressPrefix())
+	err := ec.c.CallContext(ctx, &result, "platon_getCode", address, toBlockNumArg(blockNumber))
 	return result, err
 }
 
@@ -327,7 +330,8 @@ func (ec *Client) CodeAt(ctx context.Context, account common.Address, blockNumbe
 // The block number can be nil, in which case the nonce is taken from the latest known block.
 func (ec *Client) NonceAt(ctx context.Context, account common.Address, blockNumber *big.Int) (uint64, error) {
 	var result hexutil.Uint64
-	err := ec.c.CallContext(ctx, &result, "platon_getTransactionCount", account, toBlockNumArg(blockNumber))
+	address := account.Bech32WithPrefix(common.GetAddressPrefix())
+	err := ec.c.CallContext(ctx, &result, "platon_getTransactionCount", address, toBlockNumArg(blockNumber))
 	return uint64(result), err
 }
 
@@ -379,21 +383,24 @@ func toFilterArg(q platon.FilterQuery) (interface{}, error) {
 // PendingBalanceAt returns the wei balance of the given account in the pending state.
 func (ec *Client) PendingBalanceAt(ctx context.Context, account common.Address) (*big.Int, error) {
 	var result hexutil.Big
-	err := ec.c.CallContext(ctx, &result, "platon_getBalance", account, "pending")
+	address := account.Bech32WithPrefix(common.GetAddressPrefix())
+	err := ec.c.CallContext(ctx, &result, "platon_getBalance", address, "pending")
 	return (*big.Int)(&result), err
 }
 
 // PendingStorageAt returns the value of key in the contract storage of the given account in the pending state.
 func (ec *Client) PendingStorageAt(ctx context.Context, account common.Address, key common.Hash) ([]byte, error) {
 	var result hexutil.Bytes
-	err := ec.c.CallContext(ctx, &result, "platon_getStorageAt", account, key, "pending")
+	address := account.Bech32WithPrefix(common.GetAddressPrefix())
+	err := ec.c.CallContext(ctx, &result, "platon_getStorageAt", address, key, "pending")
 	return result, err
 }
 
 // PendingCodeAt returns the contract code of the given account in the pending state.
 func (ec *Client) PendingCodeAt(ctx context.Context, account common.Address) ([]byte, error) {
 	var result hexutil.Bytes
-	err := ec.c.CallContext(ctx, &result, "platon_getCode", account, "pending")
+	address := account.Bech32WithPrefix(common.GetAddressPrefix())
+	err := ec.c.CallContext(ctx, &result, "platon_getCode", address, "pending")
 	return result, err
 }
 
@@ -401,7 +408,8 @@ func (ec *Client) PendingCodeAt(ctx context.Context, account common.Address) ([]
 // This is the nonce that should be used for the next transaction.
 func (ec *Client) PendingNonceAt(ctx context.Context, account common.Address) (uint64, error) {
 	var result hexutil.Uint64
-	err := ec.c.CallContext(ctx, &result, "platon_getTransactionCount", account, "pending")
+	address := account.Bech32WithPrefix(common.GetAddressPrefix())
+	err := ec.c.CallContext(ctx, &result, "platon_getTransactionCount", address, "pending")
 	return uint64(result), err
 }
 
@@ -496,9 +504,12 @@ func (ec *Client) GetProgramVersion(ctx context.Context) (*params.ProgramVersion
 }
 
 func toCallArg(msg platon.CallMsg) interface{} {
+	from := msg.From.Bech32WithPrefix(common.GetAddressPrefix())
+	to := msg.To.Bech32WithPrefix(common.GetAddressPrefix())
+
 	arg := map[string]interface{}{
-		"from": msg.From,
-		"to":   msg.To,
+		"from": from,
+		"to":   to,
 	}
 	if len(msg.Data) > 0 {
 		arg["data"] = hexutil.Bytes(msg.Data)

--- a/ethclient/ethclient_test.go
+++ b/ethclient/ethclient_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"math/big"
 	"reflect"
+	"strconv"
 	"testing"
 
 	ethereum "github.com/PlatONnetwork/PlatON-Go"
@@ -44,7 +45,7 @@ var (
 )
 
 const (
-	host = ""
+	host = "https://openapi.alaya.network/rpc"
 )
 
 func TestPlatonCall(t *testing.T) {
@@ -71,7 +72,7 @@ func TestPlatonCall(t *testing.T) {
 		{
 			"get_nonce",
 			address,
-			2523,
+			"2523",
 			nil,
 		},
 	} {
@@ -98,9 +99,10 @@ func TestPlatonCall(t *testing.T) {
 					if testCase.err.Error() != err.Error() {
 						t.Fatalf("expected error %v but got %v", testCase.err, err)
 					}
-				} else if !reflect.DeepEqual(testCase.output, output) {
+				} else if !reflect.DeepEqual(testCase.output, strconv.FormatUint(output, 10)) {
 					t.Fatalf("expected filter arg %v but got %v", testCase.output, output)
 				}
+			default:
 			}
 		})
 	}


### PR DESCRIPTION
ethclient fix [issue](https://github.com/PlatONnetwork/PlatON-Go/issues/1648)