### PR TITLE
Improve performance

### DIFF
--- a/crypto/secp256k1/secp256.go
+++ b/crypto/secp256k1/secp256.go
@@ -8,10 +8,19 @@ package secp256k1
 /*
 #cgo CFLAGS: -I./libsecp256k1
 #cgo CFLAGS: -I./libsecp256k1/src/
+
+#ifdef __SIZEOF_INT128__
+#  define HAVE___INT128
+#  define USE_FIELD_5X52
+#  define USE_SCALAR_4X64
+#else
+#  define USE_FIELD_10X26
+#  define USE_SCALAR_8X32
+#endif
+
+#define USE_ENDOMORPHISM
 #define USE_NUM_NONE
-#define USE_FIELD_10X26
 #define USE_FIELD_INV_BUILTIN
-#define USE_SCALAR_8X32
 #define USE_SCALAR_INV_BUILTIN
 #define NDEBUG
 #include "./libsecp256k1/src/secp256k1.c"
@@ -28,6 +37,7 @@ import (
 	"errors"
 	"math/big"
 	"unsafe"
+
 	"github.com/PlatONnetwork/PlatON-Go/common/math"
 )
 
@@ -173,6 +183,5 @@ func PubkeyNotInfinity(x, y *big.Int) bool {
 	math.ReadBits(y, point[32:])
 	pointPtr := (*C.uchar)(unsafe.Pointer(&point[0]))
 	res := C.secp256k1_pubkey_is_infinity(context, pointPtr)
-	return  res ==0
+	return res == 0
 }
-

--- a/eth/api_tps_cal.go
+++ b/eth/api_tps_cal.go
@@ -137,9 +137,9 @@ func AnalyzeStressTest(configPaths []string, output string, t int) error {
 		latencyCell := row.AddCell()
 		latencyCell.Value = strconv.FormatInt(d[1], 10)
 		tpsCell := row.AddCell()
-		tpsCell.Value = strconv.FormatInt(d[2], 10)
+		tpsCell.SetInt64(d[2])
 		ttfCell := row.AddCell()
-		ttfCell.Value = strconv.FormatInt(d[3], 10)
+		ttfCell.SetInt64(d[3])
 		if i == 0 {
 			totalReceive := row.AddCell()
 			totalReceive.Value = strconv.FormatInt(int64(total), 10)

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -798,7 +798,7 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 			p.MarkTransaction(tx.Hash())
 		}
 
-		go pm.txpool.AddRemotes(txs)
+		pm.txpool.AddRemotes(txs)
 
 	default:
 		return errResp(ErrInvalidMsgCode, "%v", msg.Code)
@@ -871,7 +871,6 @@ func (pm *ProtocolManager) BroadcastTxs(txs types.Transactions) {
 				txset[peer] = append(txset[peer], tx)
 			}
 		} else {
-			rand.Seed(time.Now().UnixNano())
 			indexes := rand.Perm(len(peers))
 			for i := 0; i < numBroadcastTxPeers; i++ {
 				peer := peers[indexes[i]]


### PR DESCRIPTION
1.merge eth:crypto/secp256k1: enable 128-bit int code and endomorphism optimization (#21203)

2. Remote transactions enter the transaction pool in parallel according to the number of cores