### PR TITLE
The QC field in the ConfirmedViewChange wal message is allowed to be empty

### DIFF
--- a/consensus/cbft/protocols/wal_protocol.go
+++ b/consensus/cbft/protocols/wal_protocol.go
@@ -88,7 +88,7 @@ type ConfirmedViewChange struct {
 	Epoch        uint64
 	ViewNumber   uint64
 	Block        *types.Block
-	QC           *ctypes.QuorumCert
+	QC           *ctypes.QuorumCert   `rlp:"nil"`
 	ViewChangeQC *ctypes.ViewChangeQC `rlp:"nil"`
 }
 

--- a/consensus/cbft/wal/wal_test.go
+++ b/consensus/cbft/wal/wal_test.go
@@ -269,3 +269,22 @@ func TestWalDecoder(t *testing.T) {
 	_, err = WALDecode(data, protocols.SendPrepareBlockMsg)
 	assert.NotNil(t, err)
 }
+
+func TestWalProtocalMsg(t *testing.T) {
+	vc := &protocols.ConfirmedViewChange{
+		Epoch:        epoch,
+		ViewNumber:   viewNumber,
+		Block:        newBlock(),
+		QC:           nil,
+		ViewChangeQC: buildViewChangeQC(),
+	}
+	m := &Message{
+		Timestamp: uint64(time.Now().UnixNano()),
+		Data:      vc,
+	}
+	b, err := encodeJournal(m)
+	assert.Nil(t, err)
+	msgInfo, err := WALDecode(b[10:], protocols.ConfirmedViewChangeMsg)
+	assert.Nil(t, err)
+	assert.Nil(t, msgInfo.(*protocols.ConfirmedViewChange).QC)
+}


### PR DESCRIPTION
#1808 https://github.com/PlatONnetwork/PlatON-Go/issues/1808