### PR TITLE
fix transaction error

### DIFF
--- a/accounts/abi/bind/auth.go
+++ b/accounts/abi/bind/auth.go
@@ -67,7 +67,7 @@ func NewKeyStoreTransactor(keystore *keystore.KeyStore, account accounts.Account
 			if address != account.Address {
 				return nil, ErrNotAuthorized
 			}
-			signature, err := keystore.SignHash(account, signer.Hash(tx).Bytes())
+			signature, err := keystore.SignHash(account, signer.Hash(tx, nil).Bytes())
 			if err != nil {
 				return nil, err
 			}
@@ -89,7 +89,7 @@ func NewKeyedTransactor(key *ecdsa.PrivateKey) *TransactOpts {
 			if address != keyAddr {
 				return nil, ErrNotAuthorized
 			}
-			signature, err := crypto.Sign(signer.Hash(tx).Bytes(), key)
+			signature, err := crypto.Sign(signer.Hash(tx, nil).Bytes(), key)
 			if err != nil {
 				return nil, err
 			}
@@ -124,7 +124,7 @@ func NewKeyStoreTransactorWithChainID(keystore *keystore.KeyStore, account accou
 			if address != account.Address {
 				return nil, ErrNotAuthorized
 			}
-			signature, err := keystore.SignHash(account, signer.Hash(tx).Bytes())
+			signature, err := keystore.SignHash(account, signer.Hash(tx, nil).Bytes())
 			if err != nil {
 				return nil, err
 			}
@@ -147,7 +147,7 @@ func NewKeyedTransactorWithChainID(key *ecdsa.PrivateKey, chainID *big.Int) (*Tr
 			if address != keyAddr {
 				return nil, ErrNotAuthorized
 			}
-			signature, err := crypto.Sign(signer.Hash(tx).Bytes(), key)
+			signature, err := crypto.Sign(signer.Hash(tx, nil).Bytes(), key)
 			if err != nil {
 				return nil, err
 			}

--- a/core/types/transaction_signing.go
+++ b/core/types/transaction_signing.go
@@ -51,7 +51,7 @@ func MakeSigner(config *params.ChainConfig, pip7 bool) Signer {
 
 // SignTx signs the transaction using the given signer and private key
 func SignTx(tx *Transaction, s Signer, prv *ecdsa.PrivateKey) (*Transaction, error) {
-	h := s.Hash(tx, tx.ChainId())
+	h := s.Hash(tx, nil)
 	sig, err := crypto.Sign(h[:], prv)
 	if err != nil {
 		return nil, err

--- a/core/types/transaction_signing.go
+++ b/core/types/transaction_signing.go
@@ -22,8 +22,6 @@ import (
 	"fmt"
 	"math/big"
 
-	"github.com/PlatONnetwork/PlatON-Go/log"
-
 	"github.com/PlatONnetwork/PlatON-Go/common"
 	"github.com/PlatONnetwork/PlatON-Go/crypto"
 	"github.com/PlatONnetwork/PlatON-Go/params"
@@ -53,7 +51,7 @@ func MakeSigner(config *params.ChainConfig, pip7 bool) Signer {
 
 // SignTx signs the transaction using the given signer and private key
 func SignTx(tx *Transaction, s Signer, prv *ecdsa.PrivateKey) (*Transaction, error) {
-	h := s.Hash(tx)
+	h := s.Hash(tx, tx.ChainId())
 	sig, err := crypto.Sign(h[:], prv)
 	if err != nil {
 		return nil, err
@@ -96,7 +94,7 @@ type Signer interface {
 	// given signature.
 	SignatureValues(sig []byte) (r, s, v *big.Int, err error)
 	// Hash returns the hash to be signed.
-	Hash(tx *Transaction) common.Hash
+	Hash(tx *Transaction, chainId *big.Int) common.Hash
 	// Equal returns true if the given signer is the same as the receiver.
 	Equal(Signer) bool
 	// Signature return the sig info of the transaction
@@ -126,13 +124,13 @@ func (s EIP155Signer) Equal(s2 Signer) bool {
 var big8 = big.NewInt(8)
 
 func (s EIP155Signer) Sender(tx *Transaction) (common.Address, error) {
-
-	if tx.ChainId().Cmp(s.chainId) != 0 {
+	txChainId := tx.ChainId()
+	if txChainId.Cmp(s.chainId) != 0 {
 		return common.Address{}, ErrInvalidChainId
 	}
 	V := new(big.Int).Sub(tx.data.V, s.chainIdMul)
 	V.Sub(V, big8)
-	return recoverPlain(s.Hash(tx), tx.data.R, tx.data.S, V, true)
+	return recoverPlain(s.Hash(tx, txChainId), tx.data.R, tx.data.S, V, true)
 }
 
 // SignatureValues returns the raw R, S, V values corresponding to the
@@ -152,7 +150,11 @@ func (s EIP155Signer) SignatureValues(sig []byte) (R, S, V *big.Int, err error) 
 
 // Hash returns the hash to be signed by the sender.
 // It does not uniquely identify the transaction.
-func (s EIP155Signer) Hash(tx *Transaction) common.Hash {
+func (s EIP155Signer) Hash(tx *Transaction, chainId *big.Int) common.Hash {
+	cid := chainId
+	if chainId == nil {
+		cid = s.chainId
+	}
 	return rlpHash([]interface{}{
 		tx.data.AccountNonce,
 		tx.data.Price,
@@ -160,7 +162,7 @@ func (s EIP155Signer) Hash(tx *Transaction) common.Hash {
 		tx.data.Recipient,
 		tx.data.Amount,
 		tx.data.Payload,
-		s.chainId, uint(0), uint(0),
+		cid, uint(0), uint(0),
 	})
 }
 
@@ -171,12 +173,12 @@ func (s EIP155Signer) SignatureAndSender(tx *Transaction) (common.Address, []byt
 	}
 	V := new(big.Int).Sub(tx.data.V, s.chainIdMul)
 	V.Sub(V, big8)
-	return recoverPubKeyAndSender(s.Hash(tx), tx.data.R, tx.data.S, V, true)
+	return recoverPubKeyAndSender(s.Hash(tx, s.chainId), tx.data.R, tx.data.S, V, true)
 }
 
 type PIP7Signer struct {
+	EIP155Signer
 	chainId, chainIdMul         *big.Int
-	IsActive                    bool
 	PIP7ChainId, PIP7ChainIdMul *big.Int
 }
 
@@ -199,60 +201,29 @@ func (s PIP7Signer) Equal(s2 Signer) bool {
 }
 
 func (s PIP7Signer) Sender(tx *Transaction) (common.Address, error) {
-
-	if tx.ChainId().Cmp(s.chainId) != 0 && tx.ChainId().Cmp(s.PIP7ChainId) != 0 {
+	txChainId := tx.ChainId()
+	if txChainId.Cmp(s.chainId) != 0 && txChainId.Cmp(s.PIP7ChainId) != 0 {
 		return common.Address{}, ErrInvalidChainId
 	}
-	V := new(big.Int).Sub(tx.data.V, s.chainIdMul)
+	h := s.Hash(tx, txChainId)
+
+	//ChainIdMul
+	V := new(big.Int).Sub(tx.data.V, txChainId.Mul(txChainId, big.NewInt(2)))
 	V.Sub(V, big8)
 
-	// PIP7ChainId
-	if err := s.adapt(V); err != nil {
-		return common.Address{}, err
-	}
-	return recoverPlain(s.Hash(tx), tx.data.R, tx.data.S, V, true)
-}
-
-func (s PIP7Signer) adapt(v *big.Int) error {
-	// PIP7ChainId
-	if v.Cmp(big.NewInt(28)) > 0 {
-		diff := new(big.Int).Sub(s.PIP7ChainIdMul, s.chainIdMul)
-		if v.Cmp(diff) > 0 {
-			v.Sub(v, diff)
-		} else {
-			log.Error("invalid chain id for signer")
-			return ErrInvalidChainId
-		}
-	}
-	return nil
+	return recoverPlain(h, tx.data.R, tx.data.S, V, true)
 }
 
 func (s PIP7Signer) SignatureAndSender(tx *Transaction) (common.Address, []byte, error) {
-	if tx.ChainId().Cmp(s.chainId) != 0 && tx.ChainId().Cmp(s.PIP7ChainId) != 0 {
+	txChainId := tx.ChainId()
+	if txChainId.Cmp(s.chainId) != 0 && txChainId.Cmp(s.PIP7ChainId) != 0 {
 		return common.Address{}, []byte{}, ErrInvalidChainId
 	}
-	V := new(big.Int).Sub(tx.data.V, s.chainIdMul)
+	//ChainIdMul
+	V := new(big.Int).Sub(tx.data.V, txChainId.Mul(txChainId, big.NewInt(2)))
 	V.Sub(V, big8)
 
-	// PIP7ChainId
-	if err := s.adapt(V); err != nil {
-		return common.Address{}, []byte{}, err
-	}
-	return recoverPubKeyAndSender(s.Hash(tx), tx.data.R, tx.data.S, V, true)
-}
-
-// Hash returns the hash to be signed by the sender.
-// It does not uniquely identify the transaction.
-func (s PIP7Signer) Hash(tx *Transaction) common.Hash {
-	return rlpHash([]interface{}{
-		tx.data.AccountNonce,
-		tx.data.Price,
-		tx.data.GasLimit,
-		tx.data.Recipient,
-		tx.data.Amount,
-		tx.data.Payload,
-		s.chainId, uint(0), uint(0),
-	})
+	return recoverPubKeyAndSender(s.Hash(tx, txChainId), tx.data.R, tx.data.S, V, true)
 }
 
 // SignatureValues returns the raw R, S, V values corresponding to the
@@ -332,8 +303,10 @@ func deriveChainId(v *big.Int) *big.Int {
 		if v == 27 || v == 28 {
 			return new(big.Int)
 		}
-		return new(big.Int).SetUint64((v - 35) / 2)
 	}
-	v = new(big.Int).Sub(v, big.NewInt(35))
-	return v.Div(v, big.NewInt(2))
+	if v.Cmp(big.NewInt(35)) >= 0 {
+		v = new(big.Int).Sub(v, big.NewInt(35))
+		return v.Div(v, big.NewInt(2))
+	}
+	return nil
 }

--- a/core/types/transaction_signing_test.go
+++ b/core/types/transaction_signing_test.go
@@ -84,12 +84,6 @@ func TestPIP7ChainId(t *testing.T) {
 		t.Error("expected chainId to be", signer.chainId, "got", tx.ChainId())
 	}
 
-	tx = NewTransaction(0, addr, new(big.Int), 0, new(big.Int), nil)
-	tx, err = SignTx(tx, signer, key)
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	from, err := signer.Sender(tx)
 	if err != nil {
 		t.Error("expected err", "err", err)

--- a/core/types/transaction_signing_test.go
+++ b/core/types/transaction_signing_test.go
@@ -70,6 +70,35 @@ func TestEIP155ChainId(t *testing.T) {
 
 }
 
+func TestPIP7ChainId(t *testing.T) {
+	key, _ := crypto.GenerateKey()
+	addr := crypto.PubkeyToAddress(key.PublicKey)
+
+	signer := NewPIP7Signer(big.NewInt(100), big.NewInt(210425))
+	tx, err := SignTx(NewTransaction(0, addr, new(big.Int), 0, new(big.Int), nil), signer, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if tx.ChainId().Cmp(signer.chainId) != 0 {
+		t.Error("expected chainId to be", signer.chainId, "got", tx.ChainId())
+	}
+
+	tx = NewTransaction(0, addr, new(big.Int), 0, new(big.Int), nil)
+	tx, err = SignTx(tx, signer, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	from, err := signer.Sender(tx)
+	if err != nil {
+		t.Error("expected err", "err", err)
+	}
+	if tx.FromAddr(signer) != from || addr != from {
+		t.Error("expected chain id is not exist")
+	}
+
+}
 func TestEIP155SigningVitalik(t *testing.T) {
 	// Test vectors come from http://vitalik.ca/files/eip155_testvec.txt
 	for i, test := range []struct {

--- a/core/types/transaction_test.go
+++ b/core/types/transaction_test.go
@@ -54,10 +54,10 @@ var (
 
 func TestTransactionSigHash(t *testing.T) {
 	var eip155 EIP155Signer
-	if eip155.Hash(emptyTx) != common.HexToHash("9044138c0fc609a18dcff53a0bb5b40b555362bbe0de85a2cd71b8a2ebf18068") {
+	if eip155.Hash(emptyTx, nil) != common.HexToHash("9044138c0fc609a18dcff53a0bb5b40b555362bbe0de85a2cd71b8a2ebf18068") {
 		t.Errorf("empty transaction hash mismatch, got %x", emptyTx.Hash())
 	}
-	if eip155.Hash(rightvrsTx) != common.HexToHash("47205c07c43ed26682dffedb77203b013cfcb08af54d1edf2cf3d651a7db43b0") {
+	if eip155.Hash(rightvrsTx, nil) != common.HexToHash("47205c07c43ed26682dffedb77203b013cfcb08af54d1edf2cf3d651a7db43b0") {
 		t.Errorf("RightVRS transaction hash mismatch, got %x", rightvrsTx.Hash())
 	}
 }

--- a/ethclient/signer.go
+++ b/ethclient/signer.go
@@ -51,7 +51,7 @@ func (s *senderFromServer) Sender(tx *types.Transaction) (common.Address, error)
 	return s.addr, nil
 }
 
-func (s *senderFromServer) Hash(tx *types.Transaction) common.Hash {
+func (s *senderFromServer) Hash(tx *types.Transaction, chainId *big.Int) common.Hash {
 	panic("can't sign with senderFromServer")
 }
 func (s *senderFromServer) SignatureValues(sig []byte) (R, S, V *big.Int, err error) {

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1532,8 +1532,9 @@ func (s *PublicTransactionPoolAPI) SendTransaction(ctx context.Context, args Sen
 
 	var chainID *big.Int
 	if config := s.b.ChainConfig(); config.IsEIP155(s.b.CurrentBlock().Number()) {
-		chainID = config.ChainID
+		chainID = config.PIP7ChainID
 	}
+	log.Info("Sign transaction with:", "ChainID", chainID.String())
 	signed, err := wallet.SignTx(account, tx, chainID)
 	if err != nil {
 		return common.Hash{}, err
@@ -1658,9 +1659,9 @@ func (s *PublicTransactionPoolAPI) Resend(ctx context.Context, sendArgs SendTxAr
 
 	for _, p := range pending {
 		var signer types.Signer = types.NewEIP155Signer(p.ChainId())
-		wantSigHash := signer.Hash(matchTx)
+		wantSigHash := signer.Hash(matchTx, p.ChainId())
 
-		if pFrom, err := types.Sender(signer, p); err == nil && pFrom == sendArgs.From && signer.Hash(p) == wantSigHash {
+		if pFrom, err := types.Sender(signer, p); err == nil && pFrom == sendArgs.From && signer.Hash(p, p.ChainId()) == wantSigHash {
 			// Match. Re-sign and send the transaction.
 			if gasPrice != nil && (*big.Int)(gasPrice).Sign() != 0 {
 				sendArgs.GasPrice = gasPrice

--- a/mobile/types.go
+++ b/mobile/types.go
@@ -239,7 +239,7 @@ func (tx *Transaction) GetCost() *BigInt { return &BigInt{tx.tx.Cost()} }
 
 // Deprecated: GetSigHash cannot know which signer to use.
 func (tx *Transaction) GetSigHash() *Hash {
-	return &Hash{types.NewEIP155Signer(new(big.Int)).Hash(tx.tx)}
+	return &Hash{types.NewEIP155Signer(new(big.Int)).Hash(tx.tx, new(big.Int))}
 }
 
 // Deprecated: use EthereumClient.TransactionSender


### PR DESCRIPTION
交易在恢复sender的时候， 不知道用户填的是哪个chainid，但是recover之前要先计算hash， hash里面有chainid
这个PR修改的地方就是计算hash时，如果交易中有chainid， 就用交易中的chainid算hash， 如果没有， 就用signer中的chainid算