### PR TITLE
Adding records of validation nodes for historical consensus rounds

### DIFF
--- a/cmd/platon/main.go
+++ b/cmd/platon/main.go
@@ -176,6 +176,7 @@ var (
 		utils.DBGCTimeoutFlag,
 		utils.DBGCMptFlag,
 		utils.DBGCBlockFlag,
+		utils.DBValidatorsHistoryFlag,
 	}
 
 	vmFlags = []cli.Flag{

--- a/cmd/platon/usage.go
+++ b/cmd/platon/usage.go
@@ -211,6 +211,7 @@ var AppHelpFlagGroups = []flagGroup{
 			utils.DBGCTimeoutFlag,
 			utils.DBGCMptFlag,
 			utils.DBGCBlockFlag,
+			utils.DBValidatorsHistoryFlag,
 		},
 	},
 	{

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -621,6 +621,10 @@ var (
 		Usage: "Number of cache block states, default 10",
 		Value: eth.DefaultConfig.DBGCBlock,
 	}
+	DBValidatorsHistoryFlag = cli.BoolFlag{
+		Name:  "db.validators_history",
+		Usage: "Store the list of validators for each consensus round",
+	}
 
 	VMWasmType = cli.StringFlag{
 		Name:   "vm.wasm_type",
@@ -1184,6 +1188,9 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *eth.Config) {
 		if b > 0 {
 			cfg.DBGCBlock = b
 		}
+	}
+	if ctx.GlobalIsSet(DBValidatorsHistoryFlag.Name) {
+		cfg.DBValidatorsHistory = ctx.GlobalBool(DBValidatorsHistoryFlag.Name)
 	}
 
 	// Read the value from the flag no matter if it's set or not.

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -325,7 +325,7 @@ func New(stack *node.Node, config *Config) (*Ethereum, error) {
 			reactor.SetVRFhandler(handler.NewVrfHandler(eth.blockchain.Genesis().Nonce()))
 			reactor.SetPluginEventMux()
 			reactor.SetPrivateKey(stack.Config().NodeKey())
-			handlePlugin(reactor, chainDb)
+			handlePlugin(reactor, chainDb, config.DBValidatorsHistory)
 			agency = reactor
 
 			//register Govern parameter verifiers
@@ -608,7 +608,7 @@ func (s *Ethereum) Stop() error {
 }
 
 // RegisterPlugin one by one
-func handlePlugin(reactor *core.BlockChainReactor, chainDB ethdb.Writer) {
+func handlePlugin(reactor *core.BlockChainReactor, chainDB ethdb.Database, isValidatorsHistory bool) {
 	xplugin.RewardMgrInstance().SetCurrentNodeID(reactor.NodeId)
 
 	reactor.RegisterPlugin(xcom.SlashingRule, xplugin.SlashInstance())
@@ -620,6 +620,11 @@ func handlePlugin(reactor *core.BlockChainReactor, chainDB ethdb.Writer) {
 	xplugin.GovPluginInstance().SetChainID(reactor.GetChainID())
 	xplugin.GovPluginInstance().SetChainDB(chainDB)
 	reactor.RegisterPlugin(xcom.GovernanceRule, xplugin.GovPluginInstance())
+
+	xplugin.StakingInstance().SetChainDB(chainDB, chainDB)
+	if isValidatorsHistory {
+		xplugin.StakingInstance().EnableValidatorsHistory()
+	}
 
 	// set rule order
 	reactor.SetBeginRule([]int{xcom.StakingRule, xcom.SlashingRule, xcom.CollectDeclareVersionRule, xcom.GovernanceRule})

--- a/eth/config.go
+++ b/eth/config.go
@@ -119,15 +119,16 @@ type Config struct {
 
 	TxLookupLimit uint64 `toml:",omitempty"` // The maximum number of blocks from head whose tx indices are reserved.
 
-	TrieCache    int
-	TrieTimeout  time.Duration
-	TrieDBCache  int
-	Preimages    bool
-	DBDisabledGC bool
-	DBGCInterval uint64
-	DBGCTimeout  time.Duration
-	DBGCMpt      bool
-	DBGCBlock    int
+	TrieCache           int
+	TrieTimeout         time.Duration
+	TrieDBCache         int
+	Preimages           bool
+	DBDisabledGC        bool
+	DBGCInterval        uint64
+	DBGCTimeout         time.Duration
+	DBGCMpt             bool
+	DBGCBlock           int
+	DBValidatorsHistory bool
 
 	// VM options
 	VMWasmType        string

--- a/params/version.go
+++ b/params/version.go
@@ -23,8 +23,8 @@ import (
 const (
 	//These versions are meaning the current code version.
 	VersionMajor = 1          // Major version component of the current release
-	VersionMinor = 3          // Minor version component of the current release
-	VersionPatch = 2          // Patch version component of the current release
+	VersionMinor = 4          // Minor version component of the current release
+	VersionPatch = 0          // Patch version component of the current release
 	VersionMeta  = "unstable" // Version metadata to append to the version string
 
 	//CAUTION: DO NOT MODIFY THIS ONCE THE CHAIN HAS BEEN INITIALIZED!!!

--- a/x/plugin/api.go
+++ b/x/plugin/api.go
@@ -14,10 +14,10 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with the PlatON-Go library. If not, see <http://www.gnu.org/licenses/>.
 
-
 package plugin
 
 import (
+	"context"
 	"fmt"
 	"github.com/PlatONnetwork/PlatON-Go/common"
 	"github.com/PlatONnetwork/PlatON-Go/core/snapshotdb"
@@ -35,6 +35,14 @@ func NewPublicPPOSAPI() *PublicPPOSAPI {
 // Get node list of zero-out blocks
 func (p *PublicPPOSAPI) GetWaitSlashingNodeList() string {
 	list, err := slash.getWaitSlashingNodeList(0, common.ZeroHash)
+	if nil != err || len(list) == 0 {
+		return ""
+	}
+	return fmt.Sprintf("%+v", list)
+}
+
+func (p *PublicPPOSAPI) GetValidatorByBlockNumber(ctx context.Context, blockNumber uint64) string {
+	list, err := stk.GetValidatorHistoryList(blockNumber)
 	if nil != err || len(list) == 0 {
 		return ""
 	}

--- a/x/plugin/staking_plugin.go
+++ b/x/plugin/staking_plugin.go
@@ -184,8 +184,9 @@ func (sk *StakingPlugin) BeginBlock(blockHash common.Hash, header *types.Header,
 				historyValidatorList[i] = hv
 				historyValidatorIDList[i] = id
 				if sk.enableValidatorsHistory {
+					dbKey := staking.HistoryValidatorDBKey(id)
 					// Check that the simplified historical node information has been stored in the DB.
-					if v, err := sk.chainReaderDB.Get(staking.HistoryValidatorDBKey(id)); err != nil && !strings.Contains(err.Error(), "not found") {
+					if v, err := sk.chainReaderDB.Get(dbKey); err != nil && !strings.Contains(err.Error(), "not found") {
 						log.Error("Failed to get history node object", "blockNumber", blockNumber, "blockHash", blockHash.TerminalString(), "err", err)
 						return err
 					} else if len(v) == 0 {
@@ -193,11 +194,11 @@ func (sk *StakingPlugin) BeginBlock(blockHash common.Hash, header *types.Header,
 							log.Error("rlp failed to encode historical node information", "blockNumber", blockNumber, "blockHash", blockHash.TerminalString(), "err", err)
 							return err
 						} else {
-							if err := sk.chainWriterDB.Put(staking.HistoryValidatorDBKey(id), enVal); err != nil {
+							if err := sk.chainWriterDB.Put(dbKey, enVal); err != nil {
 								log.Error("Failed to write to history node object", "blockNumber", blockNumber, "blockHash", blockHash.TerminalString(), "err", err)
 								return err
 							}
-							log.Debug("History node object written successfully", "blockNumber", blockNumber, "blockHash", blockHash.TerminalString(), "dbKey", hex.EncodeToString(staking.HistoryValidatorDBKey(id)))
+							log.Debug("History node object written successfully", "blockNumber", blockNumber, "blockHash", blockHash.TerminalString(), "dbKey", hex.EncodeToString(dbKey))
 						}
 					}
 				}
@@ -215,7 +216,7 @@ func (sk *StakingPlugin) BeginBlock(blockHash common.Hash, header *types.Header,
 					return err
 				}
 				log.Debug("History validator list ID written successfully", "blockNumber", blockNumber, "blockHash", blockHash.TerminalString(),
-					"dbKey", hex.EncodeToString(dbKey), "nextBlockNumber", next.Start, "nextRound", xutil.CalculateRound(blockNumber))
+					"dbKey", hex.EncodeToString(dbKey), "nextBlockNumber", next.Start, "nextRound", xutil.CalculateRound(next.Start))
 			}
 			listHash, err := historyValidatorList.Hash()
 			if err != nil {

--- a/x/plugin/staking_plugin.go
+++ b/x/plugin/staking_plugin.go
@@ -27,6 +27,7 @@ import (
 	"math/big"
 	"math/rand"
 	"strconv"
+	"strings"
 	"sync"
 
 	"github.com/PlatONnetwork/PlatON-Go/x/reward"
@@ -184,7 +185,7 @@ func (sk *StakingPlugin) BeginBlock(blockHash common.Hash, header *types.Header,
 				historyValidatorIDList[i] = id
 				if sk.enableValidatorsHistory {
 					// Check that the simplified historical node information has been stored in the DB.
-					if v, err := sk.chainReaderDB.Get(staking.HistoryValidatorDBKey(id)); err != nil && err.Error() != "not found" {
+					if v, err := sk.chainReaderDB.Get(staking.HistoryValidatorDBKey(id)); err != nil && !strings.Contains(err.Error(), "not found") {
 						log.Error("Failed to get history node object", "blockNumber", blockNumber, "blockHash", blockHash.TerminalString(), "err", err)
 						return err
 					} else if len(v) == 0 {

--- a/x/plugin/staking_plugin.go
+++ b/x/plugin/staking_plugin.go
@@ -165,7 +165,7 @@ func (sk *StakingPlugin) BeginBlock(blockHash common.Hash, header *types.Header,
 			// 1. Simplify the consensus node information
 			// 2. Calculate the identification ID
 			// 3. Compute the hash of the simplified list of node information
-			// 4. Store Hash in header.extra[0:32]
+			// 4. Replace the value of header.extra[0:32] with the Hash value.
 			// 5. Form a list of identification IDs in the order of block generation and write them into the DB
 			next, err := sk.getNextValList(blockHash, blockNumber, QueryStartNotIrr)
 			if err != nil {

--- a/x/plugin/staking_plugin.go
+++ b/x/plugin/staking_plugin.go
@@ -197,6 +197,7 @@ func (sk *StakingPlugin) BeginBlock(blockHash common.Hash, header *types.Header,
 								log.Error("Failed to write to history node object", "blockNumber", blockNumber, "blockHash", blockHash.TerminalString(), "err", err)
 								return err
 							}
+							log.Debug("History node object written successfully", "blockNumber", blockNumber, "blockHash", blockHash.TerminalString(), "dbKey", hex.EncodeToString(staking.HistoryValidatorDBKey(id)))
 						}
 					}
 				}
@@ -208,10 +209,13 @@ func (sk *StakingPlugin) BeginBlock(blockHash common.Hash, header *types.Header,
 					log.Error("rlp failed to encode ID list", "blockNumber", blockNumber, "blockHash", blockHash.TerminalString(), "err", err)
 					return err
 				}
-				if err := sk.chainWriterDB.Put(staking.HistoryValidatorIDListKey(next.Start), hvIDListEnVal); err != nil {
+				dbKey := staking.HistoryValidatorIDListKey(next.Start)
+				if err := sk.chainWriterDB.Put(dbKey, hvIDListEnVal); err != nil {
 					log.Error("Failed to write to historical consensus round node list", "blockNumber", blockNumber, "blockHash", blockHash.TerminalString(), "err", err)
 					return err
 				}
+				log.Debug("History validator list ID written successfully", "blockNumber", blockNumber, "blockHash", blockHash.TerminalString(),
+					"dbKey", hex.EncodeToString(dbKey), "nextBlockNumber", next.Start, "nextRound", xutil.CalculateRound(blockNumber))
 			}
 			listHash, err := historyValidatorList.Hash()
 			if err != nil {
@@ -260,6 +264,8 @@ func (sk *StakingPlugin) GetValidatorHistoryList(targetBlockNumber uint64) ([]*s
 		}
 		resultList = append(resultList, hve)
 	}
+	log.Debug("Query the list of nodes in a given consensus wheel", "targetBlockNumber", targetBlockNumber,
+		"targetRound", xutil.CalculateRound(targetBlockNumber), "listLength", len(resultList))
 	return resultList, nil
 }
 

--- a/x/plugin/staking_plugin_test.go
+++ b/x/plugin/staking_plugin_test.go
@@ -17,12 +17,15 @@
 package plugin
 
 import (
+	"bytes"
 	"crypto/ecdsa"
 	"crypto/rand"
 	"encoding/json"
 	"fmt"
+	"github.com/PlatONnetwork/PlatON-Go/ethdb/memorydb"
 	"math/big"
 	mrand "math/rand"
+	"os"
 	"testing"
 	"time"
 
@@ -4112,5 +4115,165 @@ func TestStakingPlugin_RandSeedShuffle(t *testing.T) {
 	})
 	for i := 0; i < len(dataList); i++ {
 		assert.True(t, dataList[i] == dataListCp3[i])
+	}
+}
+
+func TestStakingPlugin_HistoryValidatorList(t *testing.T) {
+	log.Root().SetHandler(log.LvlFilterHandler(log.LvlDebug, log.StreamHandler(os.Stderr, log.TerminalFormat(true))))
+	state := mock.NewMockStateDB()
+	newPlugins()
+	build_gov_data(state)
+	diskDB := memorydb.New()
+	StakingInstance().SetChainDB(diskDB, diskDB)
+	StakingInstance().EnableValidatorsHistory()
+	// Set to the latest version.
+	gov.AddActiveVersion(params.CodeVersion(), 0, state)
+	sndb := snapshotdb.Instance()
+	defer func() {
+		sndb.Clear()
+	}()
+
+	if err := sndb.NewBlock(blockNumber, common.BytesToHash(crypto.Keccak256([]byte("genesis"))), blockHash); nil != err {
+		t.Error("newBlock err", err)
+		return
+	}
+	queue := make(staking.ValidatorQueue, 0)
+	for i := 0; i < int(xcom.MaxValidators()); i++ {
+		privateKey, err := crypto.GenerateKey()
+		if nil != err {
+			t.Fatalf("Failed to generate random NodeId private key: %v", err)
+		}
+		nodeId := discover.PubkeyID(&privateKey.PublicKey)
+		nodeAddr := crypto.PubkeyToNodeAddress(privateKey.PublicKey)
+		var blsKey bls.SecretKey
+		blsKey.SetByCSPRNG()
+		var blsKeyHex bls.PublicKeyHex
+		b, _ := blsKey.GetPublicKey().MarshalText()
+		if err := blsKeyHex.UnmarshalText(b); nil != err {
+			log.Error("Failed to blsKeyHex.UnmarshalText", "err", err)
+			return
+		}
+		val := &staking.Validator{
+			NodeAddress:    nodeAddr,
+			NodeId:         nodeId,
+			BlsPubKey:      blsKeyHex,
+			ProgramVersion: xutil.CalcVersion(initProgramVersion),
+		}
+		queue = append(queue, val)
+	}
+
+	start := uint64(1)
+	end := xutil.EpochSize() * xutil.ConsensusSize()
+
+	newVerifierArr := &staking.ValidatorArray{
+		Start: start,
+		End:   end,
+	}
+	newVerifierArr.Arr = queue
+	err := setVerifierList(blockHash, newVerifierArr)
+	if nil != err {
+		t.Errorf("Failed to Set Genesis VerfierList, err: %v", err)
+		return
+	}
+
+	newValidatorArr := &staking.ValidatorArray{
+		Start: start,
+		End:   xutil.ConsensusSize(),
+	}
+	newValidatorArr.Arr = queue[:int(xcom.MaxConsensusVals())]
+	err = setRoundValList(blockHash, newValidatorArr)
+	if nil != err {
+		t.Errorf("Failed to Set Genesis current round validatorList, err: %v", err)
+		return
+	}
+	newValidatorArr2 := &staking.ValidatorArray{
+		Start: newValidatorArr.End + 1,
+		End:   newValidatorArr.End + xutil.ConsensusSize(),
+	}
+	newValidatorArr2.Arr = queue[:int(xcom.MaxConsensusVals())]
+	err = setRoundValList(blockHash, newValidatorArr2)
+	if nil != err {
+		t.Errorf("Failed to Set Genesis current round validatorList, err: %v", err)
+		return
+	}
+	if err := sndb.Commit(blockHash); nil != err {
+		t.Error("Commit 1 err", err)
+		return
+	}
+
+	// Write data to DB
+	header := &types.Header{
+		ParentHash: blockHash,
+		Number:     big.NewInt(int64(xutil.ConsensusSize())),
+		Nonce:      types.EncodeNonce(crypto.Keccak256([]byte(string("history")))),
+		Extra:      make([]byte, 97),
+	}
+	if err := sndb.NewBlock(blockNumber2, blockHash, blockHash2); nil != err {
+		t.Error("newBlock 2 err", err)
+		return
+	}
+	if err := StakingInstance().BeginBlock(blockHash2, header, state); err != nil {
+		t.Fatal(err)
+	}
+	nilBytes := make([]byte, 32)
+	if bytes.Equal(header.Extra[:32], nilBytes) {
+		t.Fatal()
+	}
+	list, err := StakingInstance().GetValidatorHistoryList(newValidatorArr2.Start)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < len(list); i++ {
+		if list[i].NodeId != newValidatorArr2.Arr[i].NodeId {
+			t.Fatal("Data mismatch")
+		}
+		if list[i].BlsPubKey != newValidatorArr2.Arr[i].BlsPubKey {
+			t.Fatal("Data mismatch")
+		}
+	}
+	// Second round of writing data.
+	newValidatorArr3 := &staking.ValidatorArray{
+		Start: newValidatorArr2.End + 1,
+		End:   newValidatorArr2.End + xutil.ConsensusSize(),
+	}
+	newValidatorArr3.Arr = queue[1:int(xcom.MaxConsensusVals()+1)]
+	err = setRoundValList(blockHash2, newValidatorArr3)
+	if nil != err {
+		t.Errorf("Failed to Set Genesis current round validatorList, err: %v", err)
+		return
+	}
+	if err := sndb.Commit(blockHash2); nil != err {
+		t.Error("Commit 1 err", err)
+		return
+	}
+	header = &types.Header{
+		ParentHash: blockHash2,
+		Number:     big.NewInt(int64(newValidatorArr2.End)),
+		Nonce:      types.EncodeNonce(crypto.Keccak256([]byte(string("history")))),
+		Extra:      make([]byte, 97),
+	}
+	if err := StakingInstance().BeginBlock(blockHash3, header, state); err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Equal(header.Extra[:32], nilBytes) {
+		t.Fatal()
+	}
+	list2, err := StakingInstance().GetValidatorHistoryList(newValidatorArr3.Start)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < len(list2); i++ {
+		if list2[i].NodeId != newValidatorArr3.Arr[i].NodeId {
+			t.Fatal("Data mismatch")
+		}
+		if list2[i].BlsPubKey != newValidatorArr3.Arr[i].BlsPubKey {
+			t.Fatal("Data mismatch")
+		}
+	}
+	if list2[0].NodeId == list[0].NodeId {
+		t.Fatal("Data duplication")
+	}
+	if list2[0].BlsPubKey == list[0].BlsPubKey {
+		t.Fatal("Data duplication")
 	}
 }

--- a/x/staking/staking_types.go
+++ b/x/staking/staking_types.go
@@ -17,6 +17,7 @@
 package staking
 
 import (
+	"encoding/json"
 	"fmt"
 	"github.com/PlatONnetwork/PlatON-Go/crypto"
 	"github.com/PlatONnetwork/PlatON-Go/rlp"
@@ -1102,4 +1103,12 @@ type HistoryValidatorEx struct {
 	Address   common.NodeAddress
 	NodeId    discover.NodeID
 	BlsPubKey bls.PublicKeyHex
+}
+
+func (h *HistoryValidatorEx) String() string {
+	v, err := json.Marshal(h)
+	if err != nil {
+		panic(err)
+	}
+	return string(v)
 }

--- a/x/staking/staking_types.go
+++ b/x/staking/staking_types.go
@@ -18,6 +18,8 @@ package staking
 
 import (
 	"fmt"
+	"github.com/PlatONnetwork/PlatON-Go/crypto"
+	"github.com/PlatONnetwork/PlatON-Go/rlp"
 	"math/big"
 	"strings"
 
@@ -1031,4 +1033,73 @@ func (queue SlashQueue) String() string {
 		arr[i] = s.String()
 	}
 	return "[" + strings.Join(arr, ",") + "]"
+}
+
+// For historical node records.
+// Store historical node information and participate in hash calculation.
+type HistoryValidator struct {
+	NodeId    discover.NodeID
+	BlsPubKey bls.PublicKeyHex
+}
+
+func (hv *HistoryValidator) ID() common.Hash {
+	rawVal := make([]byte, 0)
+	rawVal = append(rawVal, hv.NodeId[:]...)
+	rawVal = append(rawVal, hv.BlsPubKey[:]...)
+	return crypto.Keccak256Hash(rawVal)
+}
+
+func HistoryValidatorDBKey(ID common.Hash) []byte {
+	prefix := []byte("hn")
+	return append(prefix, ID.Bytes()...)
+}
+
+func (hv *HistoryValidator) Encode() ([]byte, error) {
+	enVal, err := rlp.EncodeToBytes(hv)
+	if err != nil {
+		return nil, err
+	}
+	return enVal, nil
+}
+
+func (hv *HistoryValidator) Decode(enVal []byte) error {
+	return rlp.DecodeBytes(enVal, &hv)
+}
+
+type HistoryValidatorIDList []common.Hash
+
+func HistoryValidatorIDListKey(blockNumber uint64) []byte {
+	prefix := []byte("hl")
+	roundBytes := common.Uint32ToBytes(uint32(xutil.CalculateRound(blockNumber)))
+	return append(prefix, roundBytes...)
+}
+
+func (hvil HistoryValidatorIDList) Encode() ([]byte, error) {
+	enVal, err := rlp.EncodeToBytes(hvil)
+	if err != nil {
+		return nil, err
+	}
+	return enVal, nil
+}
+
+func (hvil HistoryValidatorIDList) Decode(enVal []byte) error {
+	return rlp.DecodeBytes(enVal, &hvil)
+}
+
+type HistoryValidatorList []*HistoryValidator
+
+// Calculating the Hash of the Consensus Wheel Node List.
+func (hvl HistoryValidatorList) Hash() (common.Hash, error) {
+	enVal, err := rlp.EncodeToBytes(hvl)
+	if err != nil {
+		return common.ZeroHash, err
+	}
+	return crypto.Keccak256Hash(enVal), nil
+}
+
+// Structure returned to the external caller.
+type HistoryValidatorEx struct {
+	Address   common.NodeAddress
+	NodeId    discover.NodeID
+	BlsPubKey bls.PublicKeyHex
 }

--- a/x/xutil/calculate.go
+++ b/x/xutil/calculate.go
@@ -207,3 +207,8 @@ func IsElection(blockNumber uint64) bool {
 	mod := tmp % ConsensusSize()
 	return mod == 0
 }
+
+func IsEndOfConsensus(blockNumber uint64) bool {
+	mod := blockNumber % ConsensusSize()
+	return mod == 0
+}


### PR DESCRIPTION
Historical consensus verifier logging is supported.
The feature can be enabled via the startup parameter and is disabled by default.
Provides an RPC interface to query the list of verifiers of the consensus round to which it belongs based on the specified block height.