### PR TITLE
skip setBootstrapNodes on init operation

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -708,9 +708,8 @@ func setBootstrapNodes(ctx *cli.Context, cfg *p2p.Config) {
 	case ctx.GlobalBool(TestnetFlag.Name):
 		urls = params.TestnetBootnodes
 	case cfg.BootstrapNodes != nil:
-		return // already set, don't apply defaults.
 	case ctx.Command.Name == strings.ToLower("init"):
-		return
+		return // already set, don't apply defaults.
 	}
 	cfg.BootstrapNodes = make([]*discover.Node, 0, len(urls))
 	for _, url := range urls {

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -709,8 +709,9 @@ func setBootstrapNodes(ctx *cli.Context, cfg *p2p.Config) {
 		urls = params.TestnetBootnodes
 	case cfg.BootstrapNodes != nil:
 		return // already set, don't apply defaults.
+	case ctx.Command.Name == strings.ToLower("init"):
+		return
 	}
-
 	cfg.BootstrapNodes = make([]*discover.Node, 0, len(urls))
 	for _, url := range urls {
 		if url != "" {


### PR DESCRIPTION
skip setBootstrapNodes on init operation, otherwise it will always try to connect to mainnet and error if it cannot connect.