### PR TITLE
chore: remove unused max/min func

### DIFF
--- a/common/sort/sort_test.go
+++ b/common/sort/sort_test.go
@@ -327,12 +327,6 @@ func (d *testingData) Swap(i, j int) {
 	d.data[i], d.data[j] = d.data[j], d.data[i]
 }
 
-func min(a, b int) int {
-	if a < b {
-		return a
-	}
-	return b
-}
 
 func lg(n int) int {
 	i := 0

--- a/eth/protocols/eth/peer.go
+++ b/eth/protocols/eth/peer.go
@@ -56,13 +56,6 @@ const (
 	maxQueuedBlockAnns = 4
 )
 
-// max is a helper function which returns the larger of the two given integers.
-func max(a, b int) int {
-	if a > b {
-		return a
-	}
-	return b
-}
 
 // Peer is a collection of relevant information we have about a `eth` peer.
 type Peer struct {

--- a/p2p/discover/common.go
+++ b/p2p/discover/common.go
@@ -79,9 +79,3 @@ type ReadPacket struct {
 	Addr *net.UDPAddr
 }
 
-func min(x, y int) int {
-	if x > y {
-		return y
-	}
-	return x
-}


### PR DESCRIPTION
Go 1.21 adds built-in functions min and max.   https://tip.golang.org/doc/go1.21
Therefore, we can directly remove our own implementations and use the built-in methods with the same names. 
