### PR TITLE
expand the scope of DereferenceDB locks to avoid concurrent read/writ…

### DIFF
--- a/eth/state_accessor.go
+++ b/eth/state_accessor.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/PlatONnetwork/PlatON-Go/x/gov"
 	"time"
 
 	"github.com/PlatONnetwork/PlatON-Go/common"
@@ -202,7 +203,7 @@ func (eth *Ethereum) stateAtTransaction(ctx context.Context, block *types.Block,
 	}
 	// Lookup the statedb of parent block from the live database,
 	// otherwise regenerate it on the flight.
-	statedb, release, err := eth.StateAtBlock(ctx, parent, reexec, nil, true, false)
+	statedb, release, err := eth.StateAtBlock(ctx, parent, reexec, nil, false, false)
 	if err != nil {
 		return nil, vm.BlockContext{}, nil, nil, err
 	}
@@ -210,7 +211,7 @@ func (eth *Ethereum) stateAtTransaction(ctx context.Context, block *types.Block,
 		return nil, vm.BlockContext{}, statedb, release, nil
 	}
 	// Recompute transactions up to the target index.
-	signer := types.MakeSigner(eth.blockchain.Config(), block.Number(), true)
+	signer := types.MakeSigner(eth.blockchain.Config(), block.Number(), gov.Gte150VersionState(statedb))
 	for idx, tx := range block.Transactions() {
 		// Assemble the transaction call message and return if the requested offset
 		msg, _ := tx.AsMessage(signer, block.BaseFee())

--- a/eth/tracers/api.go
+++ b/eth/tracers/api.go
@@ -537,7 +537,7 @@ func (api *API) IntermediateRoots(ctx context.Context, hash common.Hash, config 
 	if config != nil && config.Reexec != nil {
 		reexec = *config.Reexec
 	}
-	statedb, release, err := api.backend.StateAtBlock(ctx, parent, reexec, nil, true, false)
+	statedb, release, err := api.backend.StateAtBlock(ctx, parent, reexec, nil, false, false)
 	if err != nil {
 		return nil, err
 	}
@@ -604,7 +604,7 @@ func (api *API) traceBlock(ctx context.Context, block *types.Block, config *Trac
 	if config != nil && config.Reexec != nil {
 		reexec = *config.Reexec
 	}
-	statedb, release, err := api.backend.StateAtBlock(ctx, parent, reexec, nil, true, false)
+	statedb, release, err := api.backend.StateAtBlock(ctx, parent, reexec, nil, false, false)
 	if err != nil {
 		return nil, err
 	}
@@ -747,7 +747,7 @@ func (api *API) standardTraceBlockToFile(ctx context.Context, block *types.Block
 	if config != nil && config.Reexec != nil {
 		reexec = *config.Reexec
 	}
-	statedb, release, err := api.backend.StateAtBlock(ctx, parent, reexec, nil, true, false)
+	statedb, release, err := api.backend.StateAtBlock(ctx, parent, reexec, nil, false, false)
 	if err != nil {
 		return nil, err
 	}
@@ -920,7 +920,7 @@ func (api *API) TraceCall(ctx context.Context, args ethapi.TransactionArgs, bloc
 	if config != nil && config.Reexec != nil {
 		reexec = *config.Reexec
 	}
-	statedb, release, err := api.backend.StateAtBlock(ctx, block, reexec, nil, true, false)
+	statedb, release, err := api.backend.StateAtBlock(ctx, block, reexec, nil, false, false)
 	if err != nil {
 		return nil, err
 	}

--- a/trie/database.go
+++ b/trie/database.go
@@ -541,6 +541,7 @@ func (db *Database) DereferenceDB(root common.Hash) {
 		return
 	}
 
+	db.lock.Lock()
 	nodes, storage, start := len(db.dirties), db.dirtiesSize, time.Now()
 	useless := make(map[string]struct{})
 	clearFn := func(hash []byte) {
@@ -550,7 +551,6 @@ func (db *Database) DereferenceDB(root common.Hash) {
 		}
 	}
 
-	db.lock.Lock()
 	db.dereference(root, clearFn, start)
 	db.lock.Unlock()
 


### PR DESCRIPTION
Expand the scope of `DereferenceDB` locks to avoid concurrent read/write operations on the map.