### PR TITLE
refactor: use the built-in max to simplify the code

### DIFF
--- a/common/bitutil/bitutil.go
+++ b/common/bitutil/bitutil.go
@@ -27,10 +27,7 @@ func XORBytes(dst, a, b []byte) int {
 // fastXORBytes xors in bulk. It only works on architectures that support
 // unaligned read/writes.
 func fastXORBytes(dst, a, b []byte) int {
-	n := len(a)
-	if len(b) < n {
-		n = len(b)
-	}
+	n := min(len(b), len(a))
 	w := n / wordSize
 	if w > 0 {
 		dw := *(*[]uintptr)(unsafe.Pointer(&dst))
@@ -49,10 +46,7 @@ func fastXORBytes(dst, a, b []byte) int {
 // safeXORBytes xors one by one. It works on all architectures, independent if
 // it supports unaligned read/writes or not.
 func safeXORBytes(dst, a, b []byte) int {
-	n := len(a)
-	if len(b) < n {
-		n = len(b)
-	}
+	n := min(len(b), len(a))
 	for i := 0; i < n; i++ {
 		dst[i] = a[i] ^ b[i]
 	}
@@ -71,10 +65,7 @@ func ANDBytes(dst, a, b []byte) int {
 // fastANDBytes ands in bulk. It only works on architectures that support
 // unaligned read/writes.
 func fastANDBytes(dst, a, b []byte) int {
-	n := len(a)
-	if len(b) < n {
-		n = len(b)
-	}
+	n := min(len(b), len(a))
 	w := n / wordSize
 	if w > 0 {
 		dw := *(*[]uintptr)(unsafe.Pointer(&dst))
@@ -93,10 +84,7 @@ func fastANDBytes(dst, a, b []byte) int {
 // safeANDBytes ands one by one. It works on all architectures, independent if
 // it supports unaligned read/writes or not.
 func safeANDBytes(dst, a, b []byte) int {
-	n := len(a)
-	if len(b) < n {
-		n = len(b)
-	}
+	n := min(len(b), len(a))
 	for i := 0; i < n; i++ {
 		dst[i] = a[i] & b[i]
 	}
@@ -115,10 +103,7 @@ func ORBytes(dst, a, b []byte) int {
 // fastORBytes ors in bulk. It only works on architectures that support
 // unaligned read/writes.
 func fastORBytes(dst, a, b []byte) int {
-	n := len(a)
-	if len(b) < n {
-		n = len(b)
-	}
+	n := min(len(b), len(a))
 	w := n / wordSize
 	if w > 0 {
 		dw := *(*[]uintptr)(unsafe.Pointer(&dst))
@@ -137,10 +122,7 @@ func fastORBytes(dst, a, b []byte) int {
 // safeORBytes ors one by one. It works on all architectures, independent if
 // it supports unaligned read/writes or not.
 func safeORBytes(dst, a, b []byte) int {
-	n := len(a)
-	if len(b) < n {
-		n = len(b)
-	}
+	n := min(len(b), len(a))
 	for i := 0; i < n; i++ {
 		dst[i] = a[i] | b[i]
 	}

--- a/common/fdlimit/fdlimit_unix.go
+++ b/common/fdlimit/fdlimit_unix.go
@@ -31,10 +31,7 @@ func Raise(max uint64) (uint64, error) {
 		return 0, err
 	}
 	// Try to update the limit to the max allowance
-	limit.Cur = limit.Max
-	if limit.Cur > max {
-		limit.Cur = max
-	}
+	limit.Cur = min(limit.Max, max)
 	if err := syscall.Setrlimit(syscall.RLIMIT_NOFILE, &limit); err != nil {
 		return 0, err
 	}

--- a/common/hexutil/hexutil.go
+++ b/common/hexutil/hexutil.go
@@ -38,7 +38,6 @@ import (
 	"strconv"
 )
 
-
 // Errors
 var (
 	ErrEmptyString   = &decError{"empty hex string"}
@@ -147,10 +146,7 @@ func DecodeBig(input string) (*big.Int, error) {
 	words := make([]big.Word, len(raw)/bigWordNibbles+1)
 	end := len(raw)
 	for i := range words {
-		start := end - bigWordNibbles
-		if start < 0 {
-			start = 0
-		}
+		start := max(end-bigWordNibbles, 0)
 		for ri := start; ri < end; ri++ {
 			nib := decodeNibble(raw[ri])
 			if nib == badNibble {

--- a/common/hexutil/json.go
+++ b/common/hexutil/json.go
@@ -176,10 +176,7 @@ func (b *Big) UnmarshalText(input []byte) error {
 	words := make([]big.Word, len(raw)/bigWordNibbles+1)
 	end := len(raw)
 	for i := range words {
-		start := end - bigWordNibbles
-		if start < 0 {
-			start = 0
-		}
+		start := max(end-bigWordNibbles, 0)
 		for ri := start; ri < end; ri++ {
 			nib := decodeNibble(raw[ri])
 			if nib == badNibble {

--- a/common/json/scanner_test.go
+++ b/common/json/scanner_test.go
@@ -204,10 +204,7 @@ func TestIndentErrors(t *testing.T) {
 func diff(t *testing.T, a, b []byte) {
 	for i := 0; ; i++ {
 		if i >= len(a) || i >= len(b) || a[i] != b[i] {
-			j := i - 10
-			if j < 0 {
-				j = 0
-			}
+			j := max(i-10, 0)
 			t.Errorf("diverge at %d: «%s» vs «%s»", i, trim(a[j:]), trim(b[j:]))
 			return
 		}
@@ -271,10 +268,7 @@ func genString(stddev float64) string {
 }
 
 func genArray(n int) []interface{} {
-	f := int(math.Abs(rand.NormFloat64()) * math.Min(10, float64(n/2)))
-	if f > n {
-		f = n
-	}
+	f := min(int(math.Abs(rand.NormFloat64())*math.Min(10, float64(n/2))), n)
 	if f < 1 {
 		f = 1
 	}
@@ -286,10 +280,7 @@ func genArray(n int) []interface{} {
 }
 
 func genMap(n int) map[string]interface{} {
-	f := int(math.Abs(rand.NormFloat64()) * math.Min(10, float64(n/2)))
-	if f > n {
-		f = n
-	}
+	f := min(int(math.Abs(rand.NormFloat64())*math.Min(10, float64(n/2))), n)
 	if n > 0 && f == 0 {
 		f = 1
 	}

--- a/p2p/netutil/net.go
+++ b/p2p/netutil/net.go
@@ -280,10 +280,7 @@ func (s *DistinctNetSet) key(ip net.IP) net.IP {
 	if ip4 := ip.To4(); ip4 != nil {
 		typ, ip = '4', ip4
 	}
-	bits := s.Subnet
-	if bits > uint(len(ip)*8) {
-		bits = uint(len(ip) * 8)
-	}
+	bits := min(s.Subnet, uint(len(ip)*8))
 	// Encode the prefix into s.buf.
 	nb := int(bits / 8)
 	mask := ^byte(0xFF >> (bits % 8))

--- a/rlp/decode.go
+++ b/rlp/decode.go
@@ -289,10 +289,7 @@ func decodeSliceElems(s *Stream, val reflect.Value, elemdec decoder) error {
 	for ; ; i++ {
 		// grow slice if necessary
 		if i >= val.Cap() {
-			newcap := val.Cap() + val.Cap()/2
-			if newcap < 4 {
-				newcap = 4
-			}
+			newcap := max(val.Cap()+val.Cap()/2, 4)
 			newv := reflect.MakeSlice(val.Type(), val.Len(), newcap)
 			reflect.Copy(newv, val)
 			val.Set(newv)


### PR DESCRIPTION

In Go 1.21, the standard library includes built-in [max/min](https://pkg.go.dev/builtin@go1.21.0#max) function, which can greatly simplify the code.